### PR TITLE
fix: user 테이블 리네이밍 및 PK 변수명 통일

### DIFF
--- a/src/main/java/com/example/muaring/domain/file/Image.java
+++ b/src/main/java/com/example/muaring/domain/file/Image.java
@@ -1,7 +1,6 @@
 package com.example.muaring.domain.file;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,7 +13,7 @@ public class Image extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "image_id")
-    private Long imageId;
+    private Long id;
 
     @Column(name = "s3_key", length = 255, nullable = false)
     private String s3Key;

--- a/src/main/java/com/example/muaring/domain/group/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/Group.java
@@ -2,7 +2,7 @@ package com.example.muaring.domain.group;
 
 import com.example.muaring.domain.common.BaseEntity;
 import com.example.muaring.domain.file.Image;
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -16,11 +16,11 @@ public class Group extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "group_id")
-    private Long groupId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "admin_user_id", nullable = false)
-    private User adminUser;
+    @JoinColumn(name = "admin_member_id", nullable = false)
+    private Member adminMember;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")

--- a/src/main/java/com/example/muaring/domain/group/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/Group.java
@@ -5,6 +5,8 @@ import com.example.muaring.domain.file.Image;
 import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
 import java.time.LocalDateTime;
 
 @Entity
@@ -19,12 +21,12 @@ public class Group extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "admin_member_id", nullable = false)
-    private Member adminMember;
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Member admin;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profile_image_id")
-    private Image profileImage;
+    @JoinColumn(name = "image_id")
+    private Image image;
 
     @Column(length = 30, nullable = false)
     private String name;
@@ -38,8 +40,8 @@ public class Group extends BaseEntity {
     @Column(name = "max_members", nullable = false)
     private Integer maxMembers;
 
-    @Column(name = "is_public", nullable = false)
-    private Boolean isPublic;
+    @Column(name = "is_public", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private Boolean isPublic = true;
 
     @Column(name = "playlist_updated_at")
     private LocalDateTime playlistUpdatedAt;

--- a/src/main/java/com/example/muaring/domain/group/GroupCategory.java
+++ b/src/main/java/com/example/muaring/domain/group/GroupCategory.java
@@ -13,7 +13,7 @@ public class GroupCategory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "group_category_id")
-    private Long groupCategoryId;
+    private Long id;
 
     @Column(length = 30, nullable = false, unique = true)
     private String name;

--- a/src/main/java/com/example/muaring/domain/group/GroupInviteToken.java
+++ b/src/main/java/com/example/muaring/domain/group/GroupInviteToken.java
@@ -26,8 +26,8 @@ public class GroupInviteToken extends BaseEntity {
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private Member user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "invite_token", length = 36, nullable = false, unique = true)
     private String inviteToken;

--- a/src/main/java/com/example/muaring/domain/group/GroupInviteToken.java
+++ b/src/main/java/com/example/muaring/domain/group/GroupInviteToken.java
@@ -1,10 +1,9 @@
 package com.example.muaring.domain.group;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(
@@ -20,7 +19,7 @@ public class GroupInviteToken extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "group_invite_token_id")
-    private Long groupInviteTokenId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", nullable = false)
@@ -28,7 +27,7 @@ public class GroupInviteToken extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    private Member user;
 
     @Column(name = "invite_token", length = 36, nullable = false, unique = true)
     private String inviteToken;

--- a/src/main/java/com/example/muaring/domain/group/GroupMember.java
+++ b/src/main/java/com/example/muaring/domain/group/GroupMember.java
@@ -1,7 +1,7 @@
 package com.example.muaring.domain.group;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +9,7 @@ import lombok.*;
 @Table(
         name = "group_member",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"group_id", "user_id"})
+                @UniqueConstraint(columnNames = {"group_id", "member_id"})
         }
 )
 @Getter
@@ -19,15 +19,15 @@ public class GroupMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "group_member_id")
-    private Long groupMemberId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 20, nullable = false)

--- a/src/main/java/com/example/muaring/domain/group/GroupPlaylist.java
+++ b/src/main/java/com/example/muaring/domain/group/GroupPlaylist.java
@@ -1,7 +1,6 @@
 package com.example.muaring.domain.group;
 
 import com.example.muaring.domain.music.Music;
-import com.example.muaring.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -15,7 +14,7 @@ public class GroupPlaylist {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "group_playlist_id")
-    private Long groupPlaylistId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", nullable = false)

--- a/src/main/java/com/example/muaring/domain/group/JoinRequest.java
+++ b/src/main/java/com/example/muaring/domain/group/JoinRequest.java
@@ -1,6 +1,6 @@
 package com.example.muaring.domain.group;
 
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -14,11 +14,11 @@ public class JoinRequest {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "join_request_id")
-    private Long joinRequestId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", nullable = false)

--- a/src/main/java/com/example/muaring/domain/member/Follow.java
+++ b/src/main/java/com/example/muaring/domain/member/Follow.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -6,29 +6,29 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "interested_user",
+        name = "follow",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"follower_id", "followee_id"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class InterestedUser {
+public class Follow {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "interested_user_id")
-    private Long interestedUserId;
+    @Column(name = "follow_id")
+    private Long id;
 
-    // 관심을 표시한 사용자
+    // 팔로우를 건 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id", nullable = false)
-    private User follower;
+    private Member follower;
 
-    // 관심을 받은 사용자
+    // 팔로우 요청을 받은 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "followee_id", nullable = false)
-    private User followee;
+    private Member followee;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/muaring/domain/member/FollowRequest.java
+++ b/src/main/java/com/example/muaring/domain/member/FollowRequest.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -18,17 +18,17 @@ public class FollowRequest {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "follow_request_id")
-    private Long followRequestId;
+    private Long id;
 
     // 팔로우를 건 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id", nullable = false)
-    private User follower;
+    private Member follower;
 
     // 팔로우 요청을 받은 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "followee_id", nullable = false)
-    private User followee;
+    private Member followee;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = false)

--- a/src/main/java/com/example/muaring/domain/member/InterestedMember.java
+++ b/src/main/java/com/example/muaring/domain/member/InterestedMember.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -6,29 +6,29 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "follow",
+        name = "interested_member",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"follower_id", "followee_id"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Follow {
+public class InterestedMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "follow_id")
-    private Long followId;
+    @Column(name = "interested_member_id")
+    private Long id;
 
-    // 팔로우를 건 사용자
+    // 관심을 표시한 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id", nullable = false)
-    private User follower;
+    private Member follower;
 
-    // 팔로우 요청을 받은 사용자
+    // 관심을 받은 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "followee_id", nullable = false)
-    private User followee;
+    private Member followee;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/muaring/domain/member/Library.java
+++ b/src/main/java/com/example/muaring/domain/member/Library.java
@@ -1,7 +1,6 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import com.example.muaring.domain.music.Music;
-import com.example.muaring.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,11 +16,11 @@ public class Library {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "library_id")
-    private Long libraryId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "music_id", nullable = false)

--- a/src/main/java/com/example/muaring/domain/member/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/Member.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import com.example.muaring.domain.common.BaseEntity;
 import com.example.muaring.domain.file.Image;
@@ -8,15 +8,15 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Entity
-@Table(name = "user")
+@Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseEntity {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
-    private Long userId;
+    @Column(name = "member_id")
+    private Long id;
 
     @Column(length = 10, nullable = false)
     private String nickname;

--- a/src/main/java/com/example/muaring/domain/member/MemberArtistPreference.java
+++ b/src/main/java/com/example/muaring/domain/member/MemberArtistPreference.java
@@ -1,29 +1,28 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
-import com.example.muaring.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "user_artist_preference",
+        name = "member_artist_preference",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "artist_id"})
+                @UniqueConstraint(columnNames = {"member_id", "artist_id"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserArtistPreference {
+public class MemberArtistPreference {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_artist_id")
-    private Long userArtistId;
+    @Column(name = "member_artist_id")
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "artist_id", nullable = false)
     private String artistId;

--- a/src/main/java/com/example/muaring/domain/member/MemberGenrePreference.java
+++ b/src/main/java/com/example/muaring/domain/member/MemberGenrePreference.java
@@ -1,30 +1,29 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import com.example.muaring.domain.music.Genre;
-import com.example.muaring.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "user_genre_preference",
+        name = "member_genre_preference",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "genre_id"})
+                @UniqueConstraint(columnNames = {"member_id", "genre_id"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserGenrePreference {
+public class MemberGenrePreference {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_genre_id")
-    private Long userGenreId;
+    @Column(name = "member_genre_id")
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "genre_id", nullable = false)

--- a/src/main/java/com/example/muaring/domain/member/MemberMusicProfile.java
+++ b/src/main/java/com/example/muaring/domain/member/MemberMusicProfile.java
@@ -1,25 +1,24 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
-import com.example.muaring.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
 // 사용자 음악 취향 수치화한 테이블
 @Entity
-@Table(name = "user_music_profile")
+@Table(name = "member_music_profile")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserMusicProfile {
+public class MemberMusicProfile {
 
     @Id
-    @Column(name = "user_id")
-    private Long userId;
+    @Column(name = "member_id")
+    private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Column(name = "avg_danceability", nullable = false)
     private Double avgDanceability;

--- a/src/main/java/com/example/muaring/domain/music/Genre.java
+++ b/src/main/java/com/example/muaring/domain/music/Genre.java
@@ -13,7 +13,7 @@ public class Genre extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "genre_id")
-    private Long genreId;
+    private Long id;
 
     @Column(length = 50, nullable = false)
     private String name;

--- a/src/main/java/com/example/muaring/domain/music/Music.java
+++ b/src/main/java/com/example/muaring/domain/music/Music.java
@@ -13,7 +13,7 @@ public class Music {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "music_id")
-    private Long musicId;
+    private Long id;
 
     @Column(name = "spotify_id", length = 50, nullable = false, unique = true)
     private String spotifyId;

--- a/src/main/java/com/example/muaring/domain/music/MusicFeature.java
+++ b/src/main/java/com/example/muaring/domain/music/MusicFeature.java
@@ -12,7 +12,7 @@ public class MusicFeature {
 
     @Id
     @Column(name = "music_id")
-    private Long musicId;
+    private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId

--- a/src/main/java/com/example/muaring/domain/music/MusicGenre.java
+++ b/src/main/java/com/example/muaring/domain/music/MusicGenre.java
@@ -12,7 +12,7 @@ public class MusicGenre {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "music_genre_id")
-    private Long musicGenreId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "genre_id", nullable = false)

--- a/src/main/java/com/example/muaring/domain/notification/NotiSetting.java
+++ b/src/main/java/com/example/muaring/domain/notification/NotiSetting.java
@@ -1,6 +1,6 @@
 package com.example.muaring.domain.notification;
 
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Table(
         name = "noti_setting",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "type"})
+                @UniqueConstraint(columnNames = {"member_id", "type"})
         }
 )
 @Getter
@@ -18,11 +18,11 @@ public class NotiSetting {
 
     @Id
     @Column(name = "noti_setting_id", length = 255)
-    private String notiSettingId;
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 30, nullable = false)

--- a/src/main/java/com/example/muaring/domain/notification/Notification.java
+++ b/src/main/java/com/example/muaring/domain/notification/Notification.java
@@ -1,7 +1,7 @@
 package com.example.muaring.domain.notification;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,11 +14,11 @@ public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")
-    private Long notificationId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
-    private User receiver;
+    private Member receiver;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 30, nullable = false)

--- a/src/main/java/com/example/muaring/domain/recommendation/MemberRecommendation.java
+++ b/src/main/java/com/example/muaring/domain/recommendation/MemberRecommendation.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.user;
+package com.example.muaring.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -6,29 +6,29 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "user_recommendation",
+        name = "member_recommendation",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "recommended_user_id"})
+                @UniqueConstraint(columnNames = {"member_id", "recommended_member_id"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserRecommendation {
+public class MemberRecommendation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "recommendation_id")
-    private Long recommendationId;
+    private Long id;
 
     // 추천을 받는 사용자
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     // 추천된 사용자
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recommended_user_id", nullable = false)
-    private User recommendedUser;
+    @JoinColumn(name = "recommended_member_id", nullable = false)
+    private Member recommendedMember;
 
     @Column(name = "similarity_score", nullable = false)
     private Double similarityScore;

--- a/src/main/java/com/example/muaring/domain/recommendation/SimilarityCache.java
+++ b/src/main/java/com/example/muaring/domain/recommendation/SimilarityCache.java
@@ -1,6 +1,6 @@
 package com.example.muaring.domain.recommendation;
 
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Table(
         name = "similarity_cache",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id_a", "user_id_b"})
+                @UniqueConstraint(columnNames = {"member_id_a", "member_id_b"})
         }
 )
 @Getter
@@ -19,17 +19,17 @@ public class SimilarityCache {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "similarity_id")
-    private Long similarityId;
+    private Long id;
 
     // 사용자 A (ID 작은 쪽)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id_a", nullable = false)
-    private User userA;
+    @JoinColumn(name = "member_id_a", nullable = false)
+    private Member memberA;
 
     // 사용자 B (ID 큰 쪽)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id_b", nullable = false)
-    private User userB;
+    @JoinColumn(name = "member_id_b", nullable = false)
+    private Member memberB;
 
     @Column(name = "total_score", nullable = false)
     private Double totalScore;

--- a/src/main/java/com/example/muaring/domain/social/Comment.java
+++ b/src/main/java/com/example/muaring/domain/social/Comment.java
@@ -1,7 +1,7 @@
 package com.example.muaring.domain.social;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,15 +14,15 @@ public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
-    private Long commentId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private MusicPost post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_comment_id")

--- a/src/main/java/com/example/muaring/domain/social/Like.java
+++ b/src/main/java/com/example/muaring/domain/social/Like.java
@@ -1,6 +1,6 @@
 package com.example.muaring.domain.social;
 
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Table(
         name = "`like`",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"post_id", "user_id"})
+                @UniqueConstraint(columnNames = {"post_id", "member_id"})
         }
 )
 @Getter
@@ -19,15 +19,15 @@ public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "like_id")
-    private Long likeId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private MusicPost post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/muaring/domain/social/MusicPost.java
+++ b/src/main/java/com/example/muaring/domain/social/MusicPost.java
@@ -2,7 +2,7 @@ package com.example.muaring.domain.social;
 
 import com.example.muaring.domain.common.BaseEntity;
 import com.example.muaring.domain.group.Group;
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import com.example.muaring.domain.music.Music;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,11 +16,11 @@ public class MusicPost extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
-    private Long postId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "music_id", nullable = false)

--- a/src/main/java/com/example/muaring/domain/stats/MonthlyMemberStats.java
+++ b/src/main/java/com/example/muaring/domain/stats/MonthlyMemberStats.java
@@ -1,29 +1,29 @@
 package com.example.muaring.domain.stats;
 
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "monthly_user_stats",
+        name = "monthly_member_stats",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "year_month"})
+                @UniqueConstraint(columnNames = {"member_id", "year_month"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MonthlyUserStats {
+public class MonthlyMemberStats {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "stat_id")
-    private Long statId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     // 연월 (ex: 2025-09)
     @Column(name = "year_month", length = 10, nullable = false)

--- a/src/main/java/com/example/muaring/domain/stats/YearlyMemberStats.java
+++ b/src/main/java/com/example/muaring/domain/stats/YearlyMemberStats.java
@@ -1,29 +1,29 @@
 package com.example.muaring.domain.stats;
 
-import com.example.muaring.domain.user.User;
+import com.example.muaring.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "yearly_user_stats",
+        name = "yearly_member_stats",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "year"})
+                @UniqueConstraint(columnNames = {"member_id", "year"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class YearlyUserStats {
+public class YearlyMemberStats {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "stat_id")
-    private Long statId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     // 연도 (ex: 2025)
     @Column(name = "year", nullable = false)


### PR DESCRIPTION
## 📌 관련 이슈
#11

## ✨ 작업 내용
- user 테이블을 member 테이블로 리네이밍 (관련 테이블의 속성명도 변경 완료)
- 자바코드 내 PK 변수명을 기능명Id에서 id로 변경 및 통일

## 📸 스크린샷(선택)
X

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
X