### PR TITLE
feat: 카카오 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	// .env
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	// implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
@@ -51,6 +51,11 @@ dependencies {
 	// MapStruct
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
@@ -1,0 +1,109 @@
+package com.example.muaring.common.security;
+
+import com.example.muaring.domain.auth.exception.AuthErrorCode;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import com.example.muaring.domain.auth.exception.AuthException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+// ✨JWT 생성 및 검증
+@Component
+public class JwtTokenProvider{
+
+    @Value("${app.jwt.secret}")
+    private String secret;
+
+    @Value("${app.jwt.issuer}")
+    private String issuer;
+
+    @Value("${app.jwt.access-ttl-seconds}")
+    private long accessTtlSec;
+
+    @Value("${app.jwt.refresh-ttl-seconds}")
+    private long refreshTtlSec;
+
+    private SecretKey key;
+
+    /*
+     * ⚪ 비밀키를 생성하는 메서드
+     * @PostConstruct를 이용하여,
+     * 앱 시작 시 한번만 Key 객체를 만들어 캐싱해두고,
+     * .signWith(key)할 때마다 매번 새 Key를 만드는 것이 아닌 한 번 만들어둔 걸 재사용한다.
+     */
+    @PostConstruct
+    private void initKey() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // ⚪ AccessToken을 생성하는 메서드
+    public String generateAccessToken(Long memberId, String email) {
+        return generateToken(memberId, email, accessTtlSec);
+    }
+
+    // ⚪ RefreshToken을 생성하는 메서드
+    public String generateRefreshToken(Long memberId, String email) {
+        return generateToken(memberId, email, refreshTtlSec);
+    }
+
+    // ⚪ token을 생성하는 메서드
+    private String generateToken(Long memberId, String email, long ttlSeconds) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + ttlSeconds * 1000);
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim("email", email)
+                .issuer(issuer)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    /*
+    * ⚪ JWT 파싱 및 검증하는 메서드
+    * 서명 검증, 만료 시간 검사, 유효하지 않은 경우 예외 발생
+    * */
+    public Jws<Claims> parse(String token) {
+        return Jwts.parser()
+                .verifyWith(key)  // 서명 검증용 키 등록
+                .build()
+                .parseSignedClaims(token);  // 실제 파싱 및 검증 (만료 시간 검사 및 형식 검증)
+    }
+
+    /*
+     * ⚪ parse()를 통해 토큰 유효성을 검사하는 메서드
+     * 서명 위조, 만료 등 예외 발생 시 false 반환
+     * */
+    public boolean validate(String token) {
+        try {
+            parse(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new AuthException(AuthErrorCode.UNSUPPORTED_TOKEN);
+        } catch (MalformedJwtException e) {
+            throw new AuthException(AuthErrorCode.MALFORMED_TOKEN);
+        } catch (IllegalArgumentException | JwtException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    // ⚪ 토큰에서 사용자 ID를 추출하는 메서드
+    public Long getMemberId(String token) {
+        Claims claims = parse(token).getPayload();
+        return Long.parseLong(claims.getSubject());
+    }
+
+    // ⚪ 토큰에서 사용자 email를 추출하는 메서드
+    public String getEmail(String token) {
+        Claims claims = parse(token).getPayload();
+        return claims.get("email").toString();
+    }
+}

--- a/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
@@ -113,7 +113,11 @@ public class JwtTokenProvider{
     // ⚪ 토큰에서 사용자 ID를 추출하는 메서드
     public Long getMemberId(String token) {
         Claims claims = parse(token).getPayload();
-        return Long.parseLong(claims.getSubject());
+        try {
+            return Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
     }
 
     // ⚪ 토큰에서 사용자 email를 추출하는 메서드

--- a/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package com.example.muaring.common.security;
 
 import com.example.muaring.domain.auth.exception.AuthErrorCode;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.WeakKeyException;
 import jakarta.annotation.PostConstruct;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +11,6 @@ import com.example.muaring.domain.auth.exception.AuthException;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 // ✨JWT 생성 및 검증
@@ -38,7 +39,21 @@ public class JwtTokenProvider{
      */
     @PostConstruct
     private void initKey() {
-        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        // 환경변수 미설정/빈 값 예외 처리
+        if (secret == null || secret.isEmpty()) {
+            throw new AuthException(AuthErrorCode.INVALID_JWT_SECRET);
+        }
+
+        try {
+            byte[] keyBytes = Decoders.BASE64.decode(secret);
+            this.key = Keys.hmacShaKeyFor(keyBytes);
+        } catch (IllegalArgumentException | WeakKeyException e)  {
+            throw new AuthException(AuthErrorCode.INVALID_JWT_SECRET);
+        }
+
+        if (accessTtlSec <= 0 || refreshTtlSec <= 0) {
+            throw new  AuthException(AuthErrorCode.INVALID_JWT_TTL);
+        }
     }
 
     // ⚪ AccessToken을 생성하는 메서드

--- a/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/muaring/common/security/JwtTokenProvider.java
@@ -123,6 +123,11 @@ public class JwtTokenProvider{
     // ⚪ 토큰에서 사용자 email를 추출하는 메서드
     public String getEmail(String token) {
         Claims claims = parse(token).getPayload();
-        return claims.get("email").toString();
+        String email = (String) claims.get("email").toString();
+
+        if (email == null || email.isBlank()) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+        return email;
     }
 }

--- a/src/main/java/com/example/muaring/common/security/SecurityUtil.java
+++ b/src/main/java/com/example/muaring/common/security/SecurityUtil.java
@@ -1,0 +1,60 @@
+package com.example.muaring.common.security;
+
+import com.example.muaring.domain.auth.exception.AuthException;
+import com.example.muaring.domain.auth.exception.AuthErrorCode;
+import com.example.muaring.domain.auth.security.MemberPrincipal;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+// ✨현재 로그인한 사용자 정보를 꺼낼 수 있도록 해주는 클래스
+@Slf4j
+@UtilityClass
+public class SecurityUtil {
+
+    // ⚪ SecurityContext에서 Authentication 객체 가져오기
+    private Authentication getAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        return authentication;
+    }
+
+    // ⚪ 로그인한 사용자의 memberId 반환
+    public Long getMemberId() {
+        Authentication auth = getAuthentication();
+
+        Object principal = auth.getPrincipal();
+
+        // principal이 MemberPrincipal인지 검증
+        if (principal instanceof MemberPrincipal memberPrincipal) {
+            return memberPrincipal.getMemberId();
+        }
+
+        throw new AuthException(AuthErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    // ⚪ 로그인한 사용자의 email 반환
+    public String getMemberEmail() {
+        Authentication auth = getAuthentication();
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof MemberPrincipal memberPrincipal) {
+            return memberPrincipal.getEmail();
+        }
+
+        throw new AuthException(AuthErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    // ⚪ 로그인한 사용자의 access token 반환
+    public String getMemberAccessToken() {
+        Authentication auth = getAuthentication();
+        if (auth.getCredentials() instanceof String token) {
+            return token;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/muaring/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/muaring/common/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,85 @@
+package com.example.muaring.common.security.filter;
+
+import com.example.muaring.common.security.JwtTokenProvider;
+import com.example.muaring.domain.auth.security.MemberPrincipal;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * ✨ JWT 인증 필터
+ * - 매 HTTP 요청마다 실행되며, Authorization 헤더의 JWT을 검증해 인증 정보를 SecurityContext에 등록한다.
+ * */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+/*
+ * OncePerRequestFilter: Spring Security의 기본 Filter 구현체 중 하나로,
+ * 같은 요청이 여러번 필터 체인을 통과하더라도 단 한번만 실행된다.
+ * 따라서 JWT 검증 필터로 사용하기에 적합하다.
+ * */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null) {
+            try {
+                // 토큰 검증 및 파싱
+                if (jwtTokenProvider.validate(token)) {
+                    Long memberId = jwtTokenProvider.getMemberId(token);
+                    String email = jwtTokenProvider.getEmail(token);
+
+                    // 인증 객체 생성
+                    MemberPrincipal memberPrincipal = new MemberPrincipal(memberId, email);
+
+                    /*
+                    * UsernamePasswordAuthenticationToken: Spring Security에서 인증된 사용자를 표현하는 표준 클래스
+                    * 3개의 파라미터
+                    * 1. principal: 사용자 정보 (여기선 MemberPrincipal)
+                    * 2. credentials: 인증 수단 (여기선 jwt 토큰)
+                    * 3. authorities: 권한 목록 (지금은 빈 리스트)
+                    * */
+                    UsernamePasswordAuthenticationToken authentication
+                            = new UsernamePasswordAuthenticationToken(memberPrincipal, token, List.of());
+
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    // 모든 요청의 인증된 상태(authentication)를 SecurityContextHolder에 저장해두고, 이후 이 정보를 꺼내쓸 수 있음
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (JwtException e) {
+                    log.warn("❌ JWT 검증 실패: {}", e.getMessage());
+            }
+        }
+
+        // 모든 인증 절차를 마친 후 다음 필터로 요청을 넘긴다.
+        filterChain.doFilter(request, response);
+    }
+
+    // ⚪HTTP 요청 헤더에서 JWT 문자열만 추출하는 메서드 (Bearer 7글자를 잘라내고 실제 토큰만 반환)
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/muaring/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/muaring/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.example.muaring.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+// ✨외부 서버(카카오, 스포티파이)와의 HTTP 통신용 RestTemplate 전역 설정 클래스
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/muaring/config/SecurityConfig.java
+++ b/src/main/java/com/example/muaring/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.example.muaring.config;
+
+import com.example.muaring.common.security.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity  // Spring Security 활성화
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                /*
+                 * CSRF(Cross-Site Request Forgery) 보호 기능 비활성화
+                 * JWT 기반 인증에서는 세션이 없으므로 CSRF 토큰이 필요없기 때문이다. (CSRF는 "서버 세션 + 쿠키" 기반 인증에서만 의미가 있다.)
+                 */
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // 세션 정책을 STATELESS로
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 요청 URL 별 인가(Authorization) 정책
+                .authorizeHttpRequests(auth -> auth
+                        // 로그인, Swagger 문서는 인증없이 접근 허용 (이외의 요청은 JWT 인증 필요)
+                        .requestMatchers("/auth/**","/login/**", "/oauth2/**","/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                /*
+                 * UsernamePasswordAuthenticationFilter 전에 JWT 필터 삽입
+                 * 사용자의 모든 요청은 먼저 JwtAuthenticationFilter를 거친 뒤,
+                 * 유효한 토큰이면 SecurityContext에 인증 정보을 넣고 Controller에서 Authentication으로 현재 사용자 접근 가능
+                 */
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/config/SwaggerConfig.java
+++ b/src/main/java/com/example/muaring/config/SwaggerConfig.java
@@ -1,23 +1,31 @@
 package com.example.muaring.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "Muaring API", version = "1.0.0", description = "Muaring API입니다."),
+        security = {@SecurityRequirement(name = "bearerAuth")} // JWT 인증 추가
+)
+@SecurityScheme(
+        name = "bearerAuth", // security requirement 이름과 일치하게 한다.
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",   // 헤더에 "Authorization: Bearer <token>" 형태로 전송
+        bearerFormat = "JWT" // 형식 명시 (JWT)
+)
 public class SwaggerConfig {
 
     @Bean
-    public OpenAPI MuaringAPI() {
-        Info info = new Info()
-                .title("MuAring API")
-                .description("MuAring API입니다.")
-                .version("1.0.0");
-
+    public OpenAPI muaringAPI() {
         return new OpenAPI()
-                .addServersItem(new Server().url("/"))
-                .info(info);
+                .addServersItem(new Server().url("/"));
     }
 }

--- a/src/main/java/com/example/muaring/config/WebClientConfig.java
+++ b/src/main/java/com/example/muaring/config/WebClientConfig.java
@@ -1,0 +1,31 @@
+package com.example.muaring.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)  // 연결 시도 최대 3초
+                .responseTimeout(Duration.ofSeconds(3))  // 응답 대기 최대 3초
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(3, TimeUnit.SECONDS))  // 서버로부터 3초 동안 새로운 데이터 패키를 받지 못하면 연결 끊는다.
+                        .addHandlerLast(new WriteTimeoutHandler(3, TimeUnit.SECONDS)));  // 요청 데이터를 서버로 전송할 때 3초 동안 진행이 없으면 타임아웃
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/example/muaring/domain/auth/client/KakaoOAuthClient.java
@@ -1,0 +1,106 @@
+package com.example.muaring.domain.auth.client;
+
+import com.example.muaring.domain.auth.dto.response.KakaoMemberInfoResponseDTO;
+import com.example.muaring.domain.auth.dto.response.KakaoTokenResponseDTO;
+import com.example.muaring.domain.auth.dto.response.OAuthMemberInfoResponseDTO;
+import com.example.muaring.domain.auth.dto.response.OAuthTokenResponseDTO;
+import com.example.muaring.domain.auth.entity.AuthProvider;
+import com.example.muaring.domain.auth.exception.AuthErrorCode;
+import com.example.muaring.domain.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthClient implements OAuthProviderClient{
+
+    // 카카오 API 호출용 HTTP 클라이언트
+    private final RestTemplate restTemplate;
+
+    // ⚪ application.yml의 설정값 불러오기
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
+    @Override
+    public AuthProvider getAuthProvider() {
+        return AuthProvider.KAKAO;
+    }
+
+    // ⚪ 인가 코드(code) -> 엑세스 토큰(access_token)
+    @Override
+    public OAuthTokenResponseDTO getAccessToken(String code) {
+        // /oauth/token 엔드포인트는 폼 형식(x-www-form-urlencoded)으로 받기 때문에 해당 형식으로 요청 본문을 전송하도록 지정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("grant_type", "authorization_code");
+        map.add("client_id", clientId);
+        map.add("client_secret", clientSecret);
+        map.add("redirect_uri", redirectUri);
+        map.add("code", code);
+
+        /*
+         * map: grant_type, client_id, code, redirect_uri 등 폼 데이터(body)
+         * headers: Content-Type: application/x-www-form-urlencoded
+         * HttpEntity: map과 headers을 하나로 묶은 HTTP 요청 객체
+         * */
+        HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(map, headers);
+
+        /*
+         * 실제 카카오 서버(https://kauth.kakao.com/oauth/token)에 POST 요청
+         * */
+        ResponseEntity<KakaoTokenResponseDTO> res = restTemplate.postForEntity(
+                tokenUri, req, KakaoTokenResponseDTO.class
+        );
+
+        if (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null) {
+            throw new AuthException(AuthErrorCode.KAKAO_TOKEN_EXCHANGE_FAILED);
+        }
+        return new OAuthTokenResponseDTO(
+                res.getBody().kakaoAccessToken(),
+                res.getBody().kakaoTokenType(),
+                res.getBody().kakaoExpiresIn(),
+                res.getBody().kakaoRefreshToken(),
+                res.getBody().kakaoRefreshTokenExpiresIn()
+        );
+    }
+
+    @Override
+    public OAuthMemberInfoResponseDTO fetchMemberInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<Void> req = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoMemberInfoResponseDTO> res = restTemplate.exchange(
+                userInfoUri, HttpMethod.GET, req, KakaoMemberInfoResponseDTO.class
+        );
+
+        if  (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null) {
+            throw new AuthException(AuthErrorCode.KAKAO_MEMBER_FETCH_FAILED);
+        }
+
+        KakaoMemberInfoResponseDTO kakaoMemberInfoResponseDTO = res.getBody();
+        return new OAuthMemberInfoResponseDTO(
+                String.valueOf(kakaoMemberInfoResponseDTO.kakaoId()),
+                kakaoMemberInfoResponseDTO.kakaoAccount().kakaoEmail()
+        );
+    }
+}

--- a/src/main/java/com/example/muaring/domain/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/example/muaring/domain/auth/client/KakaoOAuthClient.java
@@ -13,14 +13,15 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 public class KakaoOAuthClient implements OAuthProviderClient{
 
-    // 카카오 API 호출용 HTTP 클라이언트
-    private final RestTemplate restTemplate;
+    private final WebClient webClient;
 
     // ⚪ application.yml의 설정값 불러오기
     @Value("${kakao.client-id}")
@@ -46,61 +47,56 @@ public class KakaoOAuthClient implements OAuthProviderClient{
     // ⚪ 인가 코드(code) -> 엑세스 토큰(access_token)
     @Override
     public OAuthTokenResponseDTO getAccessToken(String code) {
-        // /oauth/token 엔드포인트는 폼 형식(x-www-form-urlencoded)으로 받기 때문에 해당 형식으로 요청 본문을 전송하도록 지정
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", clientId);
+        formData.add("client_secret", clientSecret);
+        formData.add("redirect_uri", redirectUri);
+        formData.add("code", code);
 
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-        map.add("grant_type", "authorization_code");
-        map.add("client_id", clientId);
-        map.add("client_secret", clientSecret);
-        map.add("redirect_uri", redirectUri);
-        map.add("code", code);
+        KakaoTokenResponseDTO res = webClient.post()
+                .uri(tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError,
+                        response -> Mono.error(new AuthException(AuthErrorCode.KAKAO_TOKEN_EXCHANGE_FAILED)))
+                .bodyToMono(KakaoTokenResponseDTO.class)
+                .block();
 
-        /*
-         * map: grant_type, client_id, code, redirect_uri 등 폼 데이터(body)
-         * headers: Content-Type: application/x-www-form-urlencoded
-         * HttpEntity: map과 headers을 하나로 묶은 HTTP 요청 객체
-         * */
-        HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(map, headers);
-
-        /*
-         * 실제 카카오 서버(https://kauth.kakao.com/oauth/token)에 POST 요청
-         * */
-        ResponseEntity<KakaoTokenResponseDTO> res = restTemplate.postForEntity(
-                tokenUri, req, KakaoTokenResponseDTO.class
-        );
-
-        if (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null) {
+        if (res == null || res.kakaoAccessToken() == null) {
             throw new AuthException(AuthErrorCode.KAKAO_TOKEN_EXCHANGE_FAILED);
         }
+
         return new OAuthTokenResponseDTO(
-                res.getBody().kakaoAccessToken(),
-                res.getBody().kakaoTokenType(),
-                res.getBody().kakaoExpiresIn(),
-                res.getBody().kakaoRefreshToken(),
-                res.getBody().kakaoRefreshTokenExpiresIn()
+                res.kakaoAccessToken(),
+                res.kakaoTokenType(),
+                res.kakaoExpiresIn(),
+                res.kakaoRefreshToken(),
+                res.kakaoRefreshTokenExpiresIn()
         );
     }
 
     @Override
     public OAuthMemberInfoResponseDTO fetchMemberInfo(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
-        HttpEntity<Void> req = new HttpEntity<>(headers);
+        KakaoMemberInfoResponseDTO res = webClient.get()
+                .uri(userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        response -> Mono.error(new AuthException(AuthErrorCode.KAKAO_MEMBER_FETCH_FAILED)))
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        response -> Mono.error(new AuthException(AuthErrorCode.KAKAO_MEMBER_FETCH_FAILED)))
+                .bodyToMono(KakaoMemberInfoResponseDTO.class)
+                .block();
 
-        ResponseEntity<KakaoMemberInfoResponseDTO> res = restTemplate.exchange(
-                userInfoUri, HttpMethod.GET, req, KakaoMemberInfoResponseDTO.class
-        );
-
-        if  (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null) {
+        if (res == null || res.kakaoProviderId() == null) {
             throw new AuthException(AuthErrorCode.KAKAO_MEMBER_FETCH_FAILED);
         }
 
-        KakaoMemberInfoResponseDTO kakaoMemberInfoResponseDTO = res.getBody();
         return new OAuthMemberInfoResponseDTO(
-                String.valueOf(kakaoMemberInfoResponseDTO.kakaoId()),
-                kakaoMemberInfoResponseDTO.kakaoAccount().kakaoEmail()
+                String.valueOf(res.kakaoProviderId()),
+                res.kakaoAccount() != null ? res.kakaoAccount().kakaoEmail() : null
         );
     }
 }

--- a/src/main/java/com/example/muaring/domain/auth/client/OAuthProviderClient.java
+++ b/src/main/java/com/example/muaring/domain/auth/client/OAuthProviderClient.java
@@ -1,0 +1,12 @@
+package com.example.muaring.domain.auth.client;
+
+import com.example.muaring.domain.auth.dto.response.OAuthMemberInfoResponseDTO;
+import com.example.muaring.domain.auth.dto.response.OAuthTokenResponseDTO;
+import com.example.muaring.domain.auth.entity.AuthProvider;
+
+public interface OAuthProviderClient {
+
+    AuthProvider getAuthProvider();
+    OAuthTokenResponseDTO getAccessToken(String code);
+    OAuthMemberInfoResponseDTO fetchMemberInfo(String accessToken);
+}

--- a/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
@@ -19,12 +19,13 @@ public class AuthController {
 
     private final AuthService kakaoAuthService;
 
-    // ⚪ 카카오 서버로부터 요청되는 엔드포인트 (리다이렉트)
+    // ⚪ 카카오 서버로부터 리다이렉트 되는 엔드포인트 (테스트용)
     @GetMapping("/login/kakao")
     @Operation(summary = "카카오 인가 코드 수신", description = "카카오 서버로부터 요청되는 인가 코드 수신 로직입니다.")
-    public ResponseEntity<String> kakaoLoginRedirect(String code) {
-        log.info("카카오 인가 코드 수신: {}", code);
-        return ResponseEntity.ok("인가 코드: " + code);
+    public ResponseEntity<ApiResponse<String>> kakaoLoginRedirect(String code) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok("인가 코드가 생성되었습니다."));
     }
 
     @Operation(summary = "카카오 소셜 로그인", description = "카카오 소셜 로그인 로직입니다.")

--- a/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.example.muaring.domain.auth.controller;
+
+import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.domain.auth.dto.request.SocialLoginRequestDTO;
+import com.example.muaring.domain.auth.dto.response.LoginResponseDTO;
+import com.example.muaring.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService kakaoAuthService;
+
+    // ⚪ 카카오 서버로부터 요청되는 엔드포인트 (리다이렉트)
+    @GetMapping("/login/kakao")
+    @Operation(summary = "카카오 인가 코드 수신", description = "카카오 서버로부터 요청되는 인가 코드 수신 로직입니다.")
+    public ResponseEntity<String> kakaoLoginRedirect(String code) {
+        log.info("카카오 인가 코드 수신: {}", code);
+        return ResponseEntity.ok("인가 코드: " + code);
+    }
+
+    @Operation(summary = "카카오 소셜 로그인", description = "카카오 소셜 로그인 로직입니다.")
+    @PostMapping("/login/kakao")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(@RequestBody SocialLoginRequestDTO socialLoginRequestDTO) {
+        log.info("카카오 로그인 요청 수신");
+        LoginResponseDTO response = kakaoAuthService.login(socialLoginRequestDTO.code(), socialLoginRequestDTO.authProvider());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(response, socialLoginRequestDTO.authProvider() + "로그인에 성공했습니다."));
+    }
+}

--- a/src/main/java/com/example/muaring/domain/auth/dto/request/SocialLoginRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/request/SocialLoginRequestDTO.java
@@ -1,0 +1,8 @@
+package com.example.muaring.domain.auth.dto.request;
+
+import com.example.muaring.domain.auth.entity.AuthProvider;
+
+public record SocialLoginRequestDTO(
+        String code,
+        AuthProvider authProvider
+) {}

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/KakaoMemberInfoResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/KakaoMemberInfoResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.muaring.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// ✨ 카카오 사용자 정보 응답 DTO (카카오 서버 -> 우리 서버)
+public record KakaoMemberInfoResponseDTO(
+
+        @JsonProperty("id")
+        Long kakaoId, // 카카오가 발급한 고유 ID
+
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            @JsonProperty("email")
+            String kakaoEmail
+    ) {}
+}

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/KakaoMemberInfoResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/KakaoMemberInfoResponseDTO.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record KakaoMemberInfoResponseDTO(
 
         @JsonProperty("id")
-        Long kakaoId, // 카카오가 발급한 고유 ID
+        Long kakaoProviderId, // 카카오가 발급한 고유 ID
 
         @JsonProperty("kakao_account")
         KakaoAccount kakaoAccount

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/KakaoTokenResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/KakaoTokenResponseDTO.java
@@ -1,0 +1,22 @@
+package com.example.muaring.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// ✨카카오 토큰 발급 응답 DTO (카카오 서버 -> 우리 서버)
+public record KakaoTokenResponseDTO(
+
+        @JsonProperty("access_token")
+        String kakaoAccessToken, // 카카오에서 발급한 accessToken
+
+        @JsonProperty("token_type")
+        String kakaoTokenType,  // 인증방식 (ex.bearer)
+
+        @JsonProperty("expires_in")
+        Integer kakaoExpiresIn,  // 해당 값은 optional 이므로 값이 빠질 수 있기에 int가 아닌 Integer 사용
+
+        @JsonProperty("refresh_token")
+        String kakaoRefreshToken,  // 카카오에서 발급한 refreshToken
+
+        @JsonProperty("refresh_token_expires_in")
+        Integer kakaoRefreshTokenExpiresIn
+) { }

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/LoginResponseDTO.java
@@ -1,0 +1,10 @@
+package com.example.muaring.domain.auth.dto.response;
+
+// ✨소셜에서 받은 정보를 이용해 우리 DB에서 사용자를 찾고 우리 서비스용 JWT를 발급한 뒤 클라이언트에 응답하는 DTO (우리 서버 -> 클라이언트(안드로이드 앱))
+public record LoginResponseDTO(
+        String accessToken,
+        String refreshToken,
+        Long memberId,
+        String email,
+        boolean hasNickname
+) { }

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/OAuthMemberInfoResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/OAuthMemberInfoResponseDTO.java
@@ -1,0 +1,6 @@
+package com.example.muaring.domain.auth.dto.response;
+
+public record OAuthMemberInfoResponseDTO(
+        String providerId, // 카카오: Long, 스포티파이: String
+        String email
+) {}

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/OAuthTokenResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/OAuthTokenResponseDTO.java
@@ -1,0 +1,10 @@
+package com.example.muaring.domain.auth.dto.response;
+
+public record OAuthTokenResponseDTO(
+
+        String accessToken,
+        String tokenType,
+        Integer expiresIn,
+        String refreshToken,
+        Integer refreshTokenExpiresIn
+) {}

--- a/src/main/java/com/example/muaring/domain/auth/entity/AuthProvider.java
+++ b/src/main/java/com/example/muaring/domain/auth/entity/AuthProvider.java
@@ -1,0 +1,7 @@
+package com.example.muaring.domain.auth.entity;
+
+public enum AuthProvider {
+
+    KAKAO,
+    SPOTIFY
+}

--- a/src/main/java/com/example/muaring/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,25 @@
+package com.example.muaring.domain.auth.exception;
+
+import com.example.muaring.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    KAKAO_TOKEN_EXCHANGE_FAILED(1001, HttpStatus.BAD_GATEWAY, "카카오 엑세스 토큰 발급에 실패했습니다."),
+    INVALID_TOKEN(1002, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(1003, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    UNSUPPORTED_TOKEN(1004, HttpStatus.UNAUTHORIZED, "지원되지 않는 토큰 형식입니다."),
+    MALFORMED_TOKEN(1005, HttpStatus.UNAUTHORIZED, "손상된 토큰입니다."),
+    KAKAO_MEMBER_FETCH_FAILED(1006, HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 조회에 실패했습니다."),
+    PROVIDER_NOT_SUPPORTED(1007, HttpStatus.BAD_REQUEST, "지원되지 않는 인증 제공자입니다."),
+    UNAUTHORIZED_ACCESS(1008, HttpStatus.UNAUTHORIZED, "로그인이 필요한 요청입니다.")
+    ;
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/muaring/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/auth/exception/AuthErrorCode.java
@@ -9,14 +9,23 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-    KAKAO_TOKEN_EXCHANGE_FAILED(1001, HttpStatus.BAD_GATEWAY, "카카오 엑세스 토큰 발급에 실패했습니다."),
+    // 400
+    PROVIDER_NOT_SUPPORTED(1001, HttpStatus.BAD_REQUEST, "지원되지 않는 인증 제공자입니다."),
+
+    // 401
     INVALID_TOKEN(1002, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(1003, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     UNSUPPORTED_TOKEN(1004, HttpStatus.UNAUTHORIZED, "지원되지 않는 토큰 형식입니다."),
     MALFORMED_TOKEN(1005, HttpStatus.UNAUTHORIZED, "손상된 토큰입니다."),
-    KAKAO_MEMBER_FETCH_FAILED(1006, HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 조회에 실패했습니다."),
-    PROVIDER_NOT_SUPPORTED(1007, HttpStatus.BAD_REQUEST, "지원되지 않는 인증 제공자입니다."),
-    UNAUTHORIZED_ACCESS(1008, HttpStatus.UNAUTHORIZED, "로그인이 필요한 요청입니다.")
+    UNAUTHORIZED_ACCESS(1006, HttpStatus.UNAUTHORIZED, "로그인이 필요한 요청입니다."),
+
+    // 500
+    KAKAO_MEMBER_FETCH_FAILED(1007, HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 조회에 실패했습니다."),
+    INVALID_JWT_SECRET(1008, HttpStatus.INTERNAL_SERVER_ERROR, "JWT 시크릿 키가 유효하지 않거나 Base64로 인코딩되지 않았습니다."),
+    INVALID_JWT_TTL(1009, HttpStatus.INTERNAL_SERVER_ERROR, "JWT TTL 설정값이 올바르지 않습니다."),
+
+    // 502
+    KAKAO_TOKEN_EXCHANGE_FAILED(1010, HttpStatus.BAD_GATEWAY, "카카오 엑세스 토큰 발급에 실패했습니다."),
     ;
 
     private final int code;

--- a/src/main/java/com/example/muaring/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/example/muaring/domain/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.example.muaring.domain.auth.exception;
+
+import com.example.muaring.common.exception.GeneralException;
+
+public class AuthException extends GeneralException {
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/muaring/domain/auth/security/MemberPrincipal.java
+++ b/src/main/java/com/example/muaring/domain/auth/security/MemberPrincipal.java
@@ -1,0 +1,13 @@
+package com.example.muaring.domain.auth.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// ✨ JWT에서 꺼낸 정보만 최소로 보관하는 객체 (인증 객체)
+@Getter
+@AllArgsConstructor
+public class MemberPrincipal {
+
+    private final Long memberId;
+    private final String email;
+}

--- a/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
@@ -1,0 +1,62 @@
+package com.example.muaring.domain.auth.service;
+
+import com.example.muaring.domain.auth.client.OAuthProviderClient;
+import com.example.muaring.domain.auth.dto.response.*;
+import com.example.muaring.domain.auth.entity.AuthProvider;
+import com.example.muaring.domain.auth.exception.AuthErrorCode;
+import com.example.muaring.domain.auth.exception.AuthException;
+import com.example.muaring.domain.member.repository.OAuthAccountRepository;
+import com.example.muaring.common.security.JwtTokenProvider;
+import com.example.muaring.domain.member.entity.Member;
+import com.example.muaring.domain.member.entity.OAuthAccount;
+import com.example.muaring.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// ✨ 카카오 로그인의 "인가코드(code) -> 엑세스 토큰(access_token) -> 사용자 정보 -> JWT 발급" 을 담당하는 클래스
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final List<OAuthProviderClient> providerClients;
+    private final OAuthAccountRepository oauthAccountRepository;
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider; // 로그인 완료 후 JWT 생성기
+
+    @Transactional
+    public LoginResponseDTO login(String code, AuthProvider authProvider) {
+        /*
+         * 등록된 클라이언트 목록을 확인하여 해당 소셜 로그인을 처리할 수 있는 클라이언트 객체를 가져오고,
+         * 지원하지 않는 provider라면 예외 발생
+         */
+        OAuthProviderClient client = providerClients.stream()
+                .filter(c -> c.getAuthProvider() == authProvider)
+                .findFirst()
+                .orElseThrow(() -> new AuthException(AuthErrorCode.PROVIDER_NOT_SUPPORTED));
+
+        OAuthTokenResponseDTO tokenResponseDTO = client.getAccessToken(code);
+        OAuthMemberInfoResponseDTO memberInfoResponseDTO = client.fetchMemberInfo(tokenResponseDTO.accessToken());
+
+        OAuthAccount account = oauthAccountRepository
+                .findByAuthProviderAndAuthProviderId(authProvider, memberInfoResponseDTO.providerId())
+                .orElseGet(() -> createMemberAndAccount(memberInfoResponseDTO, authProvider));
+
+        String accessToken = jwtTokenProvider.generateAccessToken(account.getMember().getId(), account.getMember().getEmail());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(account.getMember().getId(), account.getMember().getEmail());
+        boolean hasNickname = account.getMember().getNickname() != null && !account.getMember().getNickname().isEmpty();
+
+        return new LoginResponseDTO(accessToken, refreshToken, account.getMember().getId(), account.getMember().getEmail(), hasNickname);
+    }
+
+    private OAuthAccount createMemberAndAccount(OAuthMemberInfoResponseDTO memberInfoResponseDTO, AuthProvider authProvider) {
+        Member member = memberRepository.findByEmail(memberInfoResponseDTO.email())
+                .orElseGet(() -> memberRepository.save(Member.CreateOAuthMember(memberInfoResponseDTO.email())
+                ));
+
+        // oAuthAccount 정보 생성
+        return oauthAccountRepository.save(OAuthAccount.createOAuthAccount(authProvider, memberInfoResponseDTO.providerId(), member));
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -33,7 +33,6 @@ public class Member extends BaseEntity {
     private String email;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Column(name="oauth_accounts")
     private List<OAuthAccount> oauthAccounts = new ArrayList<>();
 
     @Column(name = "is_public", nullable = false)

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -51,4 +51,10 @@ public class Member extends BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public static Member CreateOAuthMember(String email) {
+        Member member = new Member();
+        member.email = email;
+        return member;
+    }
 }

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -4,8 +4,12 @@ import com.example.muaring.domain.common.BaseEntity;
 import com.example.muaring.domain.file.Image;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -18,31 +22,33 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(length = 10, nullable = false)
+    @Column(length = 10)
     private String nickname;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private Image profileImage;
 
-    @Column(name = "auth_provider", length = 20, nullable = false)
-    private String authProvider;
+    @Column(name="email", nullable = false, unique = true)
+    private String email;
 
-    @Column(name = "auth_provider_id", length = 100, nullable = false)
-    private String authProviderId;
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Column(name="oauth_accounts")
+    private List<OAuthAccount> oauthAccounts = new ArrayList<>();
 
     @Column(name = "is_public", nullable = false)
-    private Boolean isPublic;
+    private Boolean isPublic = true;
 
     @Column(name = "discovery_enabled", nullable = false)
-    private Boolean discoveryEnabled;
+    private Boolean discoveryEnabled = false;
 
     @Column(name = "noti_enabled", nullable = false)
-    private Boolean notiEnabled;
+    private Boolean notiEnabled = true;
 
     @Column(name = "noti_time", nullable = false)
-    private LocalTime notiTime;
+    private LocalTime notiTime = LocalTime.of(10, 0, 0);
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/muaring/domain/member/entity/OAuthAccount.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/OAuthAccount.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "oauth_account",
-        uniqueConstraints = @UniqueConstraint(name = "uk_provider_providerId", columnNames = {"authProvider", "authProviderId"})
+        uniqueConstraints = @UniqueConstraint(name = "uk_provider_providerId", columnNames = {"auth_provider", "auth_provider_id"})
 )
 public class OAuthAccount {
 
@@ -23,7 +23,7 @@ public class OAuthAccount {
     @Column(name = "auth_provider")
     private AuthProvider authProvider;
 
-    @Column(name = "auto_provider_id")
+    @Column(name = "auth_provider_id")
     private String authProviderId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/muaring/domain/member/entity/OAuthAccount.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/OAuthAccount.java
@@ -1,0 +1,48 @@
+package com.example.muaring.domain.member.entity;
+
+import com.example.muaring.domain.auth.entity.AuthProvider;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "oauth_account",
+        uniqueConstraints = @UniqueConstraint(name = "uk_provider_providerId", columnNames = {"authProvider", "authProviderId"})
+)
+public class OAuthAccount {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "o_auth_account_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_provider")
+    private AuthProvider authProvider;
+
+    @Column(name = "auto_provider_id")
+    private String authProviderId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public static OAuthAccount createOAuthAccount(AuthProvider authProvider, String providerId, Member member) {
+        OAuthAccount oauthAccount = new OAuthAccount();
+        oauthAccount.authProvider = authProvider;
+        oauthAccount.authProviderId = providerId;
+        oauthAccount.member = member;
+        return oauthAccount;
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/member/repository/MemberRepository.java
@@ -4,6 +4,10 @@ import com.example.muaring.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/muaring/domain/member/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/example/muaring/domain/member/repository/OAuthAccountRepository.java
@@ -1,0 +1,12 @@
+package com.example.muaring.domain.member.repository;
+
+import com.example.muaring.domain.auth.entity.AuthProvider;
+import com.example.muaring.domain.member.entity.OAuthAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
+
+    Optional<OAuthAccount> findByAuthProviderAndAuthProviderId(AuthProvider authProvider, String authProviderId);
+}

--- a/src/main/java/com/example/muaring/domain/member/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/example/muaring/domain/member/repository/OAuthAccountRepository.java
@@ -2,11 +2,13 @@ package com.example.muaring.domain.member.repository;
 
 import com.example.muaring.domain.auth.entity.AuthProvider;
 import com.example.muaring.domain.member.entity.OAuthAccount;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
 
+    @EntityGraph(attributePaths = "member") // 한 번의 쿼리로 OAuthAccount와 Member를 모두 가져옴
     Optional<OAuthAccount> findByAuthProviderAndAuthProviderId(AuthProvider authProvider, String authProviderId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,22 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+
+app:
+  jwt:
+    secret: ${JWT_SECRET}
+    issuer: muaring
+    access-ttl-seconds: 3600  # 1시간
+    refresh-ttl-seconds: 604800  # 7일
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: "https://kauth.kakao.com/oauth/token"
+  user-info-uri: "https://kapi.kakao.com/v2/user/me"
+  scope: "account_email"
+
+logging:
+  level:
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## 📌 관련 이슈
closed #18

## ✨ 작업 내용
카카오 소셜 로그인을 서버 단에서 구현했습니다.
현재는 앱 화면이 없어 서버 내부에서 로그인 과정을 처리하도록 구성했습니다.
기본적인 인증 절차(Access Token 발급 및 사용자 정보 조회)까지만 완료했으며,
Refresh Token 관리, 사용자 병합 로직 등 세부 구현은 추후 리팩토링할 예정입니다.

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요
<img width="321" height="137" alt="image" src="https://github.com/user-attachments/assets/4bd43e72-44fe-490b-a26d-efec7d889a35" />

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
참고, 논의할 사항이 있다면 적어주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카카오 소셜 로그인 추가 - 사용자는 카카오 계정으로 신속하게 서비스에 로그인할 수 있습니다.
  * JWT 기반 인증 시스템 도입 - 안전한 토큰 방식의 사용자 세션 관리 시스템이 새로이 구현되었습니다.
  * 이메일 기반 계정 관리 - 사용자 계정이 이메일로 통합 관리되며, 다양한 인증 제공자 정보가 연계됩니다.

* **Documentation**
  * API 보안 문서화 - Swagger 문서에 인증 방식 및 보안 요구사항이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->