### PR TITLE
feat: S3 presigned url 반환 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 	// MapStruct
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
+	// S3
+	implementation 'software.amazon.awssdk:s3:2.25.10'
+	implementation 'software.amazon.awssdk:auth:2.25.10'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/muaring/common/security/SecurityUtil.java
+++ b/src/main/java/com/example/muaring/common/security/SecurityUtil.java
@@ -3,18 +3,19 @@ package com.example.muaring.common.security;
 import com.example.muaring.domain.auth.exception.AuthException;
 import com.example.muaring.domain.auth.exception.AuthErrorCode;
 import com.example.muaring.domain.auth.security.MemberPrincipal;
-import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 // ✨현재 로그인한 사용자 정보를 꺼낼 수 있도록 해주는 클래스
-@Slf4j
-@UtilityClass
-public class SecurityUtil {
+public final class SecurityUtil {
+
+    // 외부 인스턴스화 방지
+    private SecurityUtil() {
+        throw new UnsupportedOperationException("SecurityUtil은 유틸리티 클래스이므로 인스턴스화할 수 없습니다.");
+    }
 
     // ⚪ SecurityContext에서 Authentication 객체 가져오기
-    private Authentication getAuthentication() {
+    private static Authentication getAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getPrincipal() == null) {
@@ -24,7 +25,7 @@ public class SecurityUtil {
     }
 
     // ⚪ 로그인한 사용자의 memberId 반환
-    public Long getMemberId() {
+    public static Long getMemberId() {
         Authentication auth = getAuthentication();
 
         Object principal = auth.getPrincipal();
@@ -38,7 +39,7 @@ public class SecurityUtil {
     }
 
     // ⚪ 로그인한 사용자의 email 반환
-    public String getMemberEmail() {
+    public static String getMemberEmail() {
         Authentication auth = getAuthentication();
 
         Object principal = auth.getPrincipal();
@@ -50,7 +51,7 @@ public class SecurityUtil {
     }
 
     // ⚪ 로그인한 사용자의 access token 반환
-    public String getMemberAccessToken() {
+    public static String getMemberAccessToken() {
         Authentication auth = getAuthentication();
         if (auth.getCredentials() instanceof String token) {
             return token;

--- a/src/main/java/com/example/muaring/config/FilePolicyProperties.java
+++ b/src/main/java/com/example/muaring/config/FilePolicyProperties.java
@@ -1,0 +1,12 @@
+package com.example.muaring.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "file.policy")
+public record FilePolicyProperties (
+        Long maxSize,
+        int maxNameLength,
+        List<String> allowedTypes
+) {}

--- a/src/main/java/com/example/muaring/config/S3Config.java
+++ b/src/main/java/com/example/muaring/config/S3Config.java
@@ -16,16 +16,16 @@ public class S3Config {
 
     private final S3Properties s3Properties;
 
-    @Bean
+    @Bean(destroyMethod = "close")
     public S3Presigner s3Presigner() {
-        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
                 s3Properties.credentials().accessKey(),
                 s3Properties.credentials().secretKey()
         );
 
         return S3Presigner.builder()
                 .region(Region.of(s3Properties.region()))
-                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
                 .build();
     }
 }

--- a/src/main/java/com/example/muaring/config/S3Config.java
+++ b/src/main/java/com/example/muaring/config/S3Config.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
-@EnableConfigurationProperties({S3Properties.class})
+@EnableConfigurationProperties({S3Properties.class, FilePolicyProperties.class})
 @RequiredArgsConstructor
 public class S3Config {
 
@@ -19,8 +19,8 @@ public class S3Config {
     @Bean(destroyMethod = "close")
     public S3Presigner s3Presigner() {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
-                s3Properties.credentials().accessKey(),
-                s3Properties.credentials().secretKey()
+                s3Properties.s3().credentials().accessKey(),
+                s3Properties.s3().credentials().secretKey()
         );
 
         return S3Presigner.builder()

--- a/src/main/java/com/example/muaring/config/S3Config.java
+++ b/src/main/java/com/example/muaring/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.example.muaring.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@EnableConfigurationProperties({S3Properties.class})
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(
+                s3Properties.credentials().accessKey(),
+                s3Properties.credentials().secretKey()
+        );
+
+        return S3Presigner.builder()
+                .region(Region.of(s3Properties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/config/S3Properties.java
+++ b/src/main/java/com/example/muaring/config/S3Properties.java
@@ -9,5 +9,14 @@ public record S3Properties (
         S3 s3
 ) {
     public record Credentials(String accessKey, String secretKey) {}
-    public record S3(String bucket) {}
+
+    public record S3(
+            String bucket,
+            Presign presign
+    ) {
+        public record Presign(
+                Integer uploadExpMinutes,
+                Integer downloadExpMinutes
+        ) {}
+    }
 }

--- a/src/main/java/com/example/muaring/config/S3Properties.java
+++ b/src/main/java/com/example/muaring/config/S3Properties.java
@@ -5,18 +5,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "cloud.aws")
 public record S3Properties (
         String region,
-        Credentials credentials,
         S3 s3
 ) {
-    public record Credentials(String accessKey, String secretKey) {}
-
     public record S3(
             String bucket,
-            Presign presign
+            Presign presign,
+            Credentials credentials
     ) {
-        public record Presign(
-                Integer uploadExpMinutes,
-                Integer downloadExpMinutes
-        ) {}
+        public record Presign(Integer uploadExpMinutes, Integer downloadExpMinutes) {}
+        public record Credentials(String accessKey, String secretKey) {}
     }
 }

--- a/src/main/java/com/example/muaring/config/S3Properties.java
+++ b/src/main/java/com/example/muaring/config/S3Properties.java
@@ -1,0 +1,13 @@
+package com.example.muaring.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud.aws")
+public record S3Properties (
+        String region,
+        Credentials credentials,
+        S3 s3
+) {
+    public record Credentials(String accessKey, String secretKey) {}
+    public record S3(String bucket) {}
+}

--- a/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
+++ b/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
@@ -1,9 +1,11 @@
 package com.example.muaring.domain.file.controller;
 
 import com.example.muaring.common.response.ApiResponse;
-import com.example.muaring.domain.file.entity.ImageType;
+import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
+import com.example.muaring.domain.file.dto.PresignedUrlResponseDTO;
 import com.example.muaring.domain.file.service.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,25 +17,25 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @GetMapping("/upload-url")
+    // 파일 업로드용 presigned URL 발급 API
+    @PostMapping("/upload-presigned-url")
     @Operation(summary = "파일 업로드용 presigned URL 발급", description = "파일 업로드용 presigned URL 발급입니다.")
-    public ResponseEntity<ApiResponse<String>> getUploadUrl(
-            @RequestParam String fileName,
-            @RequestParam ImageType imageType,
-            @RequestParam Long fileSize) {
-        String presignedUploadUrl = imageService.generatePresignedUploadUrl(fileName, imageType, fileSize);
+    public ResponseEntity<ApiResponse<PresignedUrlResponseDTO>> generateUploadPresignedUrl(
+            @Valid @RequestBody ImageUploadRequestDTO request
+    ) {
+        PresignedUrlResponseDTO response = imageService.generatePresignedUploadUrl(request);
         return ResponseEntity.ok(
-                ApiResponse.ok(presignedUploadUrl, "파일 업로드용 presigned URL이 성공적으로 생성되었습니다.")
+                ApiResponse.ok(response, "파일 업로드용 presigned URL이 성공적으로 생성되었습니다.")
         );
     }
 
     // 파일 다운로드용 presigned URL 발급 API
-    @GetMapping("/{imageId}/download-url")
+    @PostMapping("/{imageId}/download-presigned-url")
     @Operation(summary = "파일 다운로드용 presigned URL 발급", description = "파일 다운로드용 presigned URL 발급입니다.")
-    public ResponseEntity<ApiResponse<String>> getDownloadUrl(@PathVariable Long imageId) {
-        String presignedDownloadUrl = imageService.generatePresignedDownloadUrl(imageId);
+    public ResponseEntity<ApiResponse<PresignedUrlResponseDTO>> generateDownloadPresignedUrl(@PathVariable Long imageId) {
+        PresignedUrlResponseDTO response = imageService.generateDownloadPresignedUrl(imageId);
         return ResponseEntity.ok(
-                ApiResponse.ok(presignedDownloadUrl, "파일 다운로드용 presigned URL이 성공적으로 조회되었습니다.")
+                ApiResponse.ok(response, "파일 다운로드용 presigned URL이 성공적으로 조회되었습니다.")
         );
     }
 }

--- a/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
+++ b/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
@@ -1,0 +1,39 @@
+package com.example.muaring.domain.file.controller;
+
+import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.domain.file.entity.ImageType;
+import com.example.muaring.domain.file.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/image")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @GetMapping("/upload-url")
+    @Operation(summary = "파일 업로드용 presigned URL 발급", description = "파일 업로드용 presigned URL 발급입니다.")
+    public ResponseEntity<ApiResponse<String>> getUploadUrl(
+            @RequestParam String fileName,
+            @RequestParam ImageType imageType,
+            @RequestParam Long fileSize) {
+        String presignedUploadUrl = imageService.generatePresignedUploadUrl(fileName, imageType, fileSize);
+        return ResponseEntity.ok(
+                ApiResponse.ok(presignedUploadUrl, "파일 업로드용 presigned URL이 성공적으로 생성되었습니다.")
+        );
+    }
+
+    // 파일 다운로드용 presigned URL 발급 API
+    @GetMapping("/{imageId}/download-url")
+    @Operation(summary = "파일 다운로드용 presigned URL 발급", description = "파일 다운로드용 presigned URL 발급입니다.")
+    public ResponseEntity<ApiResponse<String>> getDownloadUrl(@PathVariable Long imageId) {
+        String presignedDownloadUrl = imageService.generatePresignedDownloadUrl(imageId);
+        return ResponseEntity.ok(
+                ApiResponse.ok(presignedDownloadUrl, "파일 다운로드용 presigned URL이 성공적으로 조회되었습니다.")
+        );
+    }
+}

--- a/src/main/java/com/example/muaring/domain/file/dto/ImageUploadRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/ImageUploadRequestDTO.java
@@ -1,0 +1,19 @@
+package com.example.muaring.domain.file.dto;
+
+import com.example.muaring.domain.file.entity.ImageType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ImageUploadRequestDTO(
+        @NotBlank(message = "파일 이름은 필수입니다.")
+        String fileName,
+
+        @NotBlank(message = "파일 타입은 필수입니다.")
+        String fileType,
+
+        @NotNull(message = "이미지 유형은 필수입니다.")
+        ImageType imageType,
+
+        @NotNull(message = "파일 크기는 필수입니다.")
+        Long fileSize
+) { }

--- a/src/main/java/com/example/muaring/domain/file/dto/ImageUploadRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/ImageUploadRequestDTO.java
@@ -1,19 +1,35 @@
 package com.example.muaring.domain.file.dto;
 
 import com.example.muaring.domain.file.entity.ImageType;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import com.example.muaring.domain.file.exception.FileErrorCode;
+import com.example.muaring.domain.file.exception.FileException;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.*;
 
 public record ImageUploadRequestDTO(
         @NotBlank(message = "파일 이름은 필수입니다.")
         String fileName,
 
         @NotBlank(message = "파일 타입은 필수입니다.")
-        String fileType,
+        @Pattern(regexp = "^image/(jpeg|jpg|png)$", message = "지원하지 않는 이미지 형식입니다.")
+        String fileType,  // 확장자 관련
 
         @NotNull(message = "이미지 유형은 필수입니다.")
-        ImageType imageType,
+        ImageType imageType,  // MEMBER, GROUP
 
         @NotNull(message = "파일 크기는 필수입니다.")
-        Long fileSize
-) { }
+        @Positive(message = "파일 크기는 양수여야 합니다.")
+        Long fileSize,
+
+        @Nullable  // GROUP 이미지 수정시에만 필요
+        Long targetId
+) {
+        public ImageUploadRequestDTO {
+                if (imageType == ImageType.GROUP && targetId == null) {
+                        throw new FileException(FileErrorCode.TARGET_ID_REQUIRED_FOR_GROUP);
+                }
+                if (imageType == ImageType.MEMBER && targetId != null) {
+                        throw new FileException(FileErrorCode.TARGET_ID_NOT_ALLOWED_FOR_MEMBER);
+                }
+        }
+}

--- a/src/main/java/com/example/muaring/domain/file/dto/PresignedUrlResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/PresignedUrlResponseDTO.java
@@ -1,0 +1,10 @@
+package com.example.muaring.domain.file.dto;
+
+public record PresignedUrlResponseDTO(
+        String presignedUrl,
+        String s3Key
+) {
+    public static PresignedUrlResponseDTO of(String presignedUrl, String s3Key) {
+        return new PresignedUrlResponseDTO(presignedUrl, s3Key);
+    }
+}

--- a/src/main/java/com/example/muaring/domain/file/entity/Image.java
+++ b/src/main/java/com/example/muaring/domain/file/entity/Image.java
@@ -26,4 +26,15 @@ public class Image extends BaseEntity {
 
     @Column(name = "file_size", nullable = false)
     private Long fileSize;
+
+    public Image(String fileName, ImageType type, String s3Key, Long fileSize) {
+        this.fileName = fileName;
+        this.type = type;
+        this.s3Key = s3Key;
+        this.fileSize = fileSize;
+    }
+
+    public static Image create(String fileName, ImageType type, String s3Key, Long fileSize) {
+        return new Image(fileName, type, s3Key, fileSize);
+    }
 }

--- a/src/main/java/com/example/muaring/domain/file/entity/Image.java
+++ b/src/main/java/com/example/muaring/domain/file/entity/Image.java
@@ -18,8 +18,11 @@ public class Image extends BaseEntity {
     @Column(name = "file_name", length = 255, nullable = false)
     private String fileName;
 
-    @Column(name = "image_type", length = 255, nullable = false)
-    private ImageType type;
+    @Column(name = "file_type", length = 20, nullable = false)
+    private String fileType;
+
+    @Column(name = "image_type", length = 20, nullable = false)
+    private ImageType imageType;
 
     @Column(name = "s3_key", length = 255, nullable = false)
     private String s3Key;
@@ -27,14 +30,15 @@ public class Image extends BaseEntity {
     @Column(name = "file_size", nullable = false)
     private Long fileSize;
 
-    public Image(String fileName, ImageType type, String s3Key, Long fileSize) {
+    public Image(String fileName, String fileType, ImageType imageType, String s3Key, Long fileSize) {
         this.fileName = fileName;
-        this.type = type;
+        this.fileType = fileType;
+        this.imageType = imageType;
         this.s3Key = s3Key;
         this.fileSize = fileSize;
     }
 
-    public static Image create(String fileName, ImageType type, String s3Key, Long fileSize) {
-        return new Image(fileName, type, s3Key, fileSize);
+    public static Image create(String fileName, String fileType, ImageType imageType, String s3Key, Long fileSize) {
+        return new Image(fileName, fileType, imageType, s3Key, fileSize);
     }
 }

--- a/src/main/java/com/example/muaring/domain/file/entity/Image.java
+++ b/src/main/java/com/example/muaring/domain/file/entity/Image.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.file;
+package com.example.muaring.domain.file.entity;
 
 import com.example.muaring.domain.common.BaseEntity;
 import jakarta.persistence.*;
@@ -15,14 +15,14 @@ public class Image extends BaseEntity {
     @Column(name = "image_id")
     private Long id;
 
-    @Column(name = "s3_key", length = 255, nullable = false)
-    private String s3Key;
-
     @Column(name = "file_name", length = 255, nullable = false)
     private String fileName;
 
-    @Column(name = "file_type", length = 50, nullable = false)
-    private String fileType;
+    @Column(name = "image_type", length = 255, nullable = false)
+    private ImageType type;
+
+    @Column(name = "s3_key", length = 255, nullable = false)
+    private String s3Key;
 
     @Column(name = "file_size", nullable = false)
     private Long fileSize;

--- a/src/main/java/com/example/muaring/domain/file/entity/ImageType.java
+++ b/src/main/java/com/example/muaring/domain/file/entity/ImageType.java
@@ -1,0 +1,11 @@
+package com.example.muaring.domain.file.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageType {
+
+    MEMBER, GROUP;
+}

--- a/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FileErrorCode implements ErrorCode {
 
+    // 400
+    INVALID_FILE_TYPE(3001, HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+
     // 404
-    IMAGE_NOT_FOUND(3001, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
+    IMAGE_NOT_FOUND(3002, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.muaring.domain.file.exception;
+
+import com.example.muaring.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileErrorCode implements ErrorCode {
+
+    // 404
+    IMAGE_NOT_FOUND(3001, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
@@ -14,9 +14,15 @@ public enum FileErrorCode implements ErrorCode {
     INVALID_FILE_SIZE(3002, HttpStatus.BAD_REQUEST, "파일 크기가 허용 범위를 초과했습니다."),
     INVALID_FILE_NAME_EMPTY(3003, HttpStatus.BAD_REQUEST, "파일명이 비어있습니다."),
     INVALID_FILE_NAME_TOO_LONG(3004, HttpStatus.BAD_REQUEST, "파일명이 너무 깁니다."),
+    TARGET_ID_REQUIRED_FOR_GROUP(3005, HttpStatus.BAD_REQUEST, "그룹 이미지 업로드 시 targetId는 필수입니다."),
+    TARGET_ID_NOT_ALLOWED_FOR_MEMBER(3006, HttpStatus.BAD_REQUEST, "개인 프로필 이미지 업로드 시 targetId는 지정할 수 없습니다."),
+    MISSING_GROUP_ID(3007, HttpStatus.BAD_REQUEST, "그룹 아이디가 존재하지 누락되었습니다."),
+
+    // 403
+    FORBIDDEN_GROUP_IMAGE_UPLOAD(3008, HttpStatus.FORBIDDEN, "그룹 관리자만 그룹 이미지를 업로드할 수 있습니다."),
 
     // 404
-    IMAGE_NOT_FOUND(3005, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
+    IMAGE_NOT_FOUND(3009, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
@@ -11,9 +11,12 @@ public enum FileErrorCode implements ErrorCode {
 
     // 400
     INVALID_FILE_TYPE(3001, HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+    INVALID_FILE_SIZE(3002, HttpStatus.BAD_REQUEST, "파일 크기가 허용 범위를 초과했습니다."),
+    INVALID_FILE_NAME_EMPTY(3003, HttpStatus.BAD_REQUEST, "파일명이 비어있습니다."),
+    INVALID_FILE_NAME_TOO_LONG(3004, HttpStatus.BAD_REQUEST, "파일명이 너무 깁니다."),
 
     // 404
-    IMAGE_NOT_FOUND(3002, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
+    IMAGE_NOT_FOUND(3005, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/file/exception/FileException.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileException.java
@@ -1,0 +1,10 @@
+package com.example.muaring.domain.file.exception;
+
+import com.example.muaring.common.exception.GeneralException;
+import com.example.muaring.common.response.ErrorCode;
+
+public class FileException extends GeneralException {
+    public FileException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/muaring/domain/file/repository/ImageRepository.java
+++ b/src/main/java/com/example/muaring/domain/file/repository/ImageRepository.java
@@ -2,6 +2,8 @@ package com.example.muaring.domain.file.repository;
 
 import com.example.muaring.domain.file.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ImageRepository extends JpaRepository<Image,Long> {
 }

--- a/src/main/java/com/example/muaring/domain/file/repository/ImageRepository.java
+++ b/src/main/java/com/example/muaring/domain/file/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.example.muaring.domain.file.repository;
+
+import com.example.muaring.domain.file.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image,Long> {
+}

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -7,6 +7,7 @@ import com.example.muaring.domain.file.entity.Image;
 import com.example.muaring.domain.file.exception.FileErrorCode;
 import com.example.muaring.domain.file.exception.FileException;
 import com.example.muaring.domain.file.repository.ImageRepository;
+import com.example.muaring.domain.file.validator.FileValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +21,6 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -31,14 +31,12 @@ public class ImageService {
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
     private final ImageRepository imageRepository;
-    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
-            "image/jpeg", "image/png", "image/webp"
-    );
+    private final FileValidator fileValidator;
 
     // ⚪ 파일 업로드용 presigned URL 생성 메서드
     @Transactional
     public PresignedUrlResponseDTO generatePresignedUploadUrl(ImageUploadRequestDTO request) {
-        validateFileType(request.fileType());
+        fileValidator.validateImage(request);
 
         String prefix = switch (request.imageType()) {
             case MEMBER -> "member/";
@@ -109,13 +107,6 @@ public class ImageService {
                 presignedUrl.toString(),
                 image.getS3Key()
         );
-    }
-
-    // ⚪ 파일 타입을 검증하기 위한 메서드
-    public void validateFileType(String fileType) {
-        if (!ALLOWED_IMAGE_TYPES.contains(fileType)) {
-            throw new FileException(FileErrorCode.INVALID_FILE_TYPE);
-        }
     }
 
     // ⚪ 파일명을 정제하는 메서드

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -1,0 +1,78 @@
+package com.example.muaring.domain.file.service;
+
+import com.example.muaring.config.S3Properties;
+import com.example.muaring.domain.file.entity.Image;
+import com.example.muaring.domain.file.entity.ImageType;
+import com.example.muaring.domain.file.exception.FileErrorCode;
+import com.example.muaring.domain.file.exception.FileException;
+import com.example.muaring.domain.file.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Presigner s3Presigner;
+    private final S3Properties s3Properties;
+    private final ImageRepository imageRepository;
+
+    // ⚪ 파일 업로드용 presigned URL 생성 메서드
+    public String generatePresignedUploadUrl(String fileName, ImageType imageType, Long fileSize) {
+        String prefix = switch (imageType) {
+            case MEMBER -> "member/";
+            case GROUP -> "group/";
+        };
+
+        String uniqueFileName = UUID.randomUUID() + "_"  + fileName;
+        String s3Key = prefix + uniqueFileName;
+
+        // S3에 올릴 파일 정보 정의
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3Properties.s3().bucket())
+                .key(s3Key)
+                .build();
+
+        // 정의한 파일 정보에 서명하여 presigned URL 생성
+        PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        URL presignedUrl = s3Presigner.presignPutObject(putObjectPresignRequest).url();
+
+        imageRepository.save(Image.create(fileName, imageType, s3Key, fileSize));
+
+        return presignedUrl.toString();
+    }
+
+    // ⚪ 파일 다운로드용 presigned URL 생성 메서드
+    public String generatePresignedDownloadUrl(Long imageId) {
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new FileException(FileErrorCode.IMAGE_NOT_FOUND));
+
+        // S3에서 가져올 파일 정보 정의
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3Properties.s3().bucket())
+                .key(image.getS3Key())
+                .build();
+
+        // 정의한 파일 정보에 서명하여 presigned URL 생성
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5)) // 5분 유효
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        URL presignedUrl = s3Presigner.presignGetObject(presignRequest).url();
+        return presignedUrl.toString();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.example.muaring.domain.file.service;
 
+import com.example.muaring.common.security.SecurityUtil;
 import com.example.muaring.config.S3Properties;
 import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
 import com.example.muaring.domain.file.dto.PresignedUrlResponseDTO;
@@ -8,6 +9,8 @@ import com.example.muaring.domain.file.exception.FileErrorCode;
 import com.example.muaring.domain.file.exception.FileException;
 import com.example.muaring.domain.file.repository.ImageRepository;
 import com.example.muaring.domain.file.validator.FileValidator;
+import com.example.muaring.domain.group.entity.Group;
+import com.example.muaring.domain.group.repository.GroupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,10 +35,31 @@ public class ImageService {
     private final S3Properties s3Properties;
     private final ImageRepository imageRepository;
     private final FileValidator fileValidator;
+    private final GroupRepository groupRepository;
 
     // ⚪ 파일 업로드용 presigned URL 생성 메서드
     @Transactional
     public PresignedUrlResponseDTO generatePresignedUploadUrl(ImageUploadRequestDTO request) {
+        Long requesterId = SecurityUtil.getMemberId();
+
+        // 권한 검증
+        switch (request.imageType()) {
+            case MEMBER -> {}  // 본인 프로필 업로드는 별도의 권한 검증 불필요
+            case GROUP -> {
+                Long groupId = request.targetId();
+                if (groupId == null) {
+                    throw new FileException(FileErrorCode.MISSING_GROUP_ID);
+                }
+
+                Group group = groupRepository.findById(groupId)
+                        .orElseThrow(() -> new FileException(FileErrorCode.FORBIDDEN_GROUP_IMAGE_UPLOAD));
+
+                if (!group.getAdmin().getId().equals(requesterId)) {
+                    throw new FileException(FileErrorCode.FORBIDDEN_GROUP_IMAGE_UPLOAD);
+                }
+            }
+        }
+
         fileValidator.validateImage(request);
 
         String prefix = switch (request.imageType()) {

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -1,45 +1,63 @@
 package com.example.muaring.domain.file.service;
 
 import com.example.muaring.config.S3Properties;
+import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
+import com.example.muaring.domain.file.dto.PresignedUrlResponseDTO;
 import com.example.muaring.domain.file.entity.Image;
-import com.example.muaring.domain.file.entity.ImageType;
 import com.example.muaring.domain.file.exception.FileErrorCode;
 import com.example.muaring.domain.file.exception.FileException;
 import com.example.muaring.domain.file.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ImageService {
 
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
     private final ImageRepository imageRepository;
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp"
+    );
 
     // ⚪ 파일 업로드용 presigned URL 생성 메서드
-    public String generatePresignedUploadUrl(String fileName, ImageType imageType, Long fileSize) {
-        String prefix = switch (imageType) {
+    @Transactional
+    public PresignedUrlResponseDTO generatePresignedUploadUrl(ImageUploadRequestDTO request) {
+        validateFileType(request.fileType());
+
+        String prefix = switch (request.imageType()) {
             case MEMBER -> "member/";
             case GROUP -> "group/";
         };
 
-        String uniqueFileName = UUID.randomUUID() + "_"  + fileName;
-        String s3Key = prefix + uniqueFileName;
+        String s3Key = prefix + UUID.randomUUID();
 
         // S3에 올릴 파일 정보 정의
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(s3Properties.s3().bucket())
                 .key(s3Key)
+                .contentType(request.fileType())
+                .contentLength(request.fileSize())
+                .metadata(Map.of(
+                        "original-filename", safeFileName(request.fileName()),
+                        "image-type", request.fileType()
+                ))
+                .serverSideEncryption(ServerSideEncryption.AES256)  // S3에 저장시 데이터 자동 암호화
                 .build();
 
         Duration uploadDuration = Duration.ofMinutes(s3Properties.s3().presign().uploadExpMinutes());
@@ -52,13 +70,23 @@ public class ImageService {
 
         URL presignedUrl = s3Presigner.presignPutObject(putObjectPresignRequest).url();
 
-        imageRepository.save(Image.create(fileName, imageType, s3Key, fileSize));
+//        // image DB에 메타데이터 저장은 실제 프로필 수정 등에서 구현할 예정
+//        imageRepository.save(Image.create(
+//                request.fileName(),
+//                request.fileType(),
+//                request.imageType(),
+//                s3Key,
+//                request.fileSize()));
 
-        return presignedUrl.toString();
+        return PresignedUrlResponseDTO.of(
+                presignedUrl.toString(),
+                s3Key
+        );
     }
 
     // ⚪ 파일 다운로드용 presigned URL 생성 메서드
-    public String generatePresignedDownloadUrl(Long imageId) {
+    @Transactional
+    public PresignedUrlResponseDTO generateDownloadPresignedUrl(Long imageId) {
         Image image = imageRepository.findById(imageId)
                 .orElseThrow(() -> new FileException(FileErrorCode.IMAGE_NOT_FOUND));
 
@@ -77,6 +105,24 @@ public class ImageService {
                 .build();
 
         URL presignedUrl = s3Presigner.presignGetObject(presignRequest).url();
-        return presignedUrl.toString();
+        return PresignedUrlResponseDTO.of(
+                presignedUrl.toString(),
+                image.getS3Key()
+        );
+    }
+
+    // ⚪ 파일 타입을 검증하기 위한 메서드
+    public void validateFileType(String fileType) {
+        if (!ALLOWED_IMAGE_TYPES.contains(fileType)) {
+            throw new FileException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    // ⚪ 파일명을 정제하는 메서드
+    private String safeFileName(String fileName) {
+        return fileName
+                .replaceAll("[^a-zA-Z0-9._-]", "_")
+                .replaceAll("_+", "_")
+                .substring(0, Math.min(fileName.length(), 100));
     }
 }

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -42,9 +42,11 @@ public class ImageService {
                 .key(s3Key)
                 .build();
 
+        Duration uploadDuration = Duration.ofMinutes(s3Properties.s3().presign().uploadExpMinutes());
+
         // 정의한 파일 정보에 서명하여 presigned URL 생성
         PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(10))
+                .signatureDuration(uploadDuration)
                 .putObjectRequest(putObjectRequest)
                 .build();
 
@@ -66,9 +68,11 @@ public class ImageService {
                 .key(image.getS3Key())
                 .build();
 
+        Duration downloadDuration = Duration.ofMinutes(s3Properties.s3().presign().downloadExpMinutes());
+
         // 정의한 파일 정보에 서명하여 presigned URL 생성
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(5)) // 5분 유효
+                .signatureDuration(downloadDuration)
                 .getObjectRequest(getObjectRequest)
                 .build();
 

--- a/src/main/java/com/example/muaring/domain/file/validator/FileValidator.java
+++ b/src/main/java/com/example/muaring/domain/file/validator/FileValidator.java
@@ -1,48 +1,42 @@
 package com.example.muaring.domain.file.validator;
 
+import com.example.muaring.config.FilePolicyProperties;
 import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
 import com.example.muaring.domain.file.exception.FileErrorCode;
 import com.example.muaring.domain.file.exception.FileException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Set;
-
 @Component
+@RequiredArgsConstructor
 public class FileValidator {
 
-    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
-            "image/jpeg", "image/png", "image/webp"
-    );
-    private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024;  // 5MB
-    private static final int MAX_IMAGE_NAME_LENGTH = 255;
+    private final FilePolicyProperties filePolicyProperties;
 
     // ⚪ 이미지를 검증하기 위한 메서드
     public void validateImage(ImageUploadRequestDTO request) {
-        validateImageType(request.fileType());
-        validateImageSize(request.fileSize());
-        validateImageName(request.fileName());
+        validateFileType(request.fileType());
+        validateFileSize(request.fileSize());
+        validateFileName(request.fileName());
     }
 
     // ⚪ 파일 타입을 검증하기 위한 메서드
-    private void validateImageType(String fileType) {
-        if (!ALLOWED_IMAGE_TYPES.contains(fileType)) {
+    private void validateFileType(String fileType) {
+        if (!filePolicyProperties.allowedTypes().contains(fileType)) {
             throw new FileException(FileErrorCode.INVALID_FILE_TYPE);
         }
     }
 
     // ⚪ 파일 크기를 검증하기 위한 메서드
-    private void validateImageSize(Long fileSize) {
-        if (fileSize == null || fileSize > MAX_IMAGE_SIZE) {
+    private void validateFileSize(Long fileSize) {
+        if (fileSize > filePolicyProperties.maxSize()) {
             throw new FileException(FileErrorCode.INVALID_FILE_SIZE);
         }
     }
 
     // ⚪ 파일 이름을 검증하기 위한 메서드
-    private void validateImageName(String fileName) {
-        if (fileName == null || fileName.isBlank()) {
-            throw new FileException(FileErrorCode.INVALID_FILE_NAME_EMPTY);
-        }
-        if (fileName.length() > MAX_IMAGE_NAME_LENGTH) {
+    private void validateFileName(String fileName) {
+        if (fileName.length() > filePolicyProperties.maxNameLength()) {
             throw new FileException(FileErrorCode.INVALID_FILE_NAME_TOO_LONG);
         }
     }

--- a/src/main/java/com/example/muaring/domain/file/validator/FileValidator.java
+++ b/src/main/java/com/example/muaring/domain/file/validator/FileValidator.java
@@ -1,0 +1,49 @@
+package com.example.muaring.domain.file.validator;
+
+import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
+import com.example.muaring.domain.file.exception.FileErrorCode;
+import com.example.muaring.domain.file.exception.FileException;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class FileValidator {
+
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp"
+    );
+    private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024;  // 5MB
+    private static final int MAX_IMAGE_NAME_LENGTH = 255;
+
+    // ⚪ 이미지를 검증하기 위한 메서드
+    public void validateImage(ImageUploadRequestDTO request) {
+        validateImageType(request.fileType());
+        validateImageSize(request.fileSize());
+        validateImageName(request.fileName());
+    }
+
+    // ⚪ 파일 타입을 검증하기 위한 메서드
+    private void validateImageType(String fileType) {
+        if (!ALLOWED_IMAGE_TYPES.contains(fileType)) {
+            throw new FileException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    // ⚪ 파일 크기를 검증하기 위한 메서드
+    private void validateImageSize(Long fileSize) {
+        if (fileSize == null || fileSize > MAX_IMAGE_SIZE) {
+            throw new FileException(FileErrorCode.INVALID_FILE_SIZE);
+        }
+    }
+
+    // ⚪ 파일 이름을 검증하기 위한 메서드
+    private void validateImageName(String fileName) {
+        if (fileName == null || fileName.isBlank()) {
+            throw new FileException(FileErrorCode.INVALID_FILE_NAME_EMPTY);
+        }
+        if (fileName.length() > MAX_IMAGE_NAME_LENGTH) {
+            throw new FileException(FileErrorCode.INVALID_FILE_NAME_TOO_LONG);
+        }
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/entity/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/Group.java
@@ -1,7 +1,7 @@
 package com.example.muaring.domain.group.entity;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.file.Image;
+import com.example.muaring.domain.file.entity.Image;
 import com.example.muaring.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -1,7 +1,7 @@
 package com.example.muaring.domain.member.entity;
 
 import com.example.muaring.domain.common.BaseEntity;
-import com.example.muaring.domain.file.Image;
+import com.example.muaring.domain.file.entity.Image;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;

--- a/src/main/java/com/example/muaring/domain/member/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/example/muaring/domain/member/repository/OAuthAccountRepository.java
@@ -4,9 +4,11 @@ import com.example.muaring.domain.auth.entity.AuthProvider;
 import com.example.muaring.domain.member.entity.OAuthAccount;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
 
     @EntityGraph(attributePaths = "member") // 한 번의 쿼리로 OAuthAccount와 Member를 모두 가져옴

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,9 +44,18 @@ cloud:
       presign:
         upload-exp-minutes: 10
         download-exp-minutes: 5
-    credentials:
-      access-key: ${AWS_S3_ACCESS_KEY}
-      secret-key: ${AWS_S3_SECRET_KEY}
+      credentials:
+        access-key: ${AWS_S3_ACCESS_KEY}
+        secret-key: ${AWS_S3_SECRET_KEY}
+
+file:
+  policy:
+    max-size: 5242880  # 5MB (byte 단위)
+    max-name-length: 255
+    allowed-types:
+      - image/jpeg
+      - image/jpg
+      - image/png
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,9 @@ cloud:
     region: ${AWS_REGION}
     s3:
       bucket: ${AWS_BUCKET_NAME}
+      presign:
+        upload-exp-minutes: 10
+        download-exp-minutes: 5
     credentials:
       access-key: ${AWS_S3_ACCESS_KEY}
       secret-key: ${AWS_S3_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+
+cloud:
+  aws:
+    region: ${AWS_REGION}
+    s3:
+      bucket: ${AWS_BUCKET_NAME}
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}


### PR DESCRIPTION
## 📌 관련 이슈
closed #23

## ✨ 작업 내용
이미지 업로드를 위한 s3 presigned url 반환 api를 구현했습니다.

## 📸 스크린샷(선택)
swagger와 postman를 통해, 생성된 presigned url과 이미지를 넣었을 때 s3 버킷에 이미지가 업로드 되는 것을 확인했습니다.
<img width="702" height="367" alt="image" src="https://github.com/user-attachments/assets/02752e74-a43e-4c3e-a3e5-7b5d10a3c8db" />

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
[서버에서는 presigned url 발급만 담당하고, 실제 업로드는 클라이언트에서 해주어야 합니다!!]
클라이언트는 서버를 통해 Presigned URL을 발급받아 S3에 직접 업로드하고,
서버는 DB에 메타데이터 저장 + URL 발급만 담당합니다.

파일을 “보거나 다운로드”할 때도 동일하게 서버에 요청 → Presigned GET URL 발급 → 클라이언트가 S3에서 직접 가져오는 구조입니다.