### PR TITLE
feat, refactor: group 조회 api 추가, group 생성 기능 리팩토링

### DIFF
--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -2,12 +2,17 @@ package com.example.muaring.domain.group.controller;
 
 import com.example.muaring.domain.group.dto.GroupCreateRequestDto;
 import com.example.muaring.domain.group.dto.GroupCreateResponseDto;
+import com.example.muaring.domain.group.dto.GroupListResponseDto;
 import com.example.muaring.domain.group.service.GroupService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/groups")
@@ -18,9 +23,37 @@ public class GroupController {
 
     // [POST] /groups
     @PostMapping
-    public GroupCreateResponseDto createGroup(@RequestBody GroupCreateRequestDto requestDto) {
-        return groupService.createGroup(requestDto);
+    public ResponseEntity<GroupCreateResponseDto> createGroup(@RequestBody GroupCreateRequestDto requestDto) {
+        GroupCreateResponseDto responseDto = groupService.createGroup(requestDto);
+        Long newGroupId = responseDto.getGroupId();
+
+        URI location = URI.create("/groups/" + newGroupId);
+
+        return ResponseEntity.created(location).body(responseDto);
     }
 
-    // [GET] /groups?name=
+    /**
+     * [GET] /groups?isPublic
+     * 그룹 목록 동적 조회 (검색, 필터링, 페이지네이션)
+     * q, isPublic, categoryIds
+     */
+    @GetMapping
+    public ResponseEntity<GroupListResponseDto> getPublicGroups(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Boolean isPublic,
+            @RequestParam(required = false) List<Long> categoryIds,
+            @PageableDefault(size = 10, sort = "createdAt", // 추후 필요에 따라 설정 변경
+                    direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        GroupListResponseDto response = groupService.getGroups(
+                q,
+                isPublic,
+                categoryIds,
+                pageable.getPageNumber(), // 0-based page
+                pageable.getPageSize(),   // size
+                pageable.getSort()        // sort
+        );
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupCreateRequestDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupCreateRequestDto.java
@@ -1,17 +1,15 @@
 package com.example.muaring.domain.group.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 import java.util.List;
 
 @Getter
-@Setter
 public class GroupCreateRequestDto {
     private Long adminId;
     private List<Long> groupCategoryId;
     private String name;
     private String description;
     private int maxMembers;
-    private Boolean opened;
+    private Boolean isPublic;
 }

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupCreateResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupCreateResponseDto.java
@@ -7,14 +7,14 @@ import java.util.List;
 
 @Getter
 public class GroupCreateResponseDto {
-    private Long groupId;
-    private Long adminId;
-    private List<Long> groupCategoryId;
-    private String name;
-    private String description;
-    private int memberCount;
-    private int maxMembers;
-    private Boolean opened;
+    private final Long groupId;
+    private final Long adminId;
+    private final List<Long> groupCategoryId;
+    private final String name;
+    private final String description;
+    private final int memberCount;
+    private final int maxMembers;
+    private final Boolean isPublic;
 
     private GroupCreateResponseDto(Group entity, List<Long> categoryIds) {
         this.groupId = entity.getId();
@@ -24,7 +24,7 @@ public class GroupCreateResponseDto {
         this.description = entity.getDescription();
         this.memberCount = entity.getMemberCount();
         this.maxMembers = entity.getMaxMembers();
-        this.opened = entity.getOpened();
+        this.isPublic = entity.getIsPublic();
     }
 
     public static GroupCreateResponseDto from(Group entity, List<Long> categoryIds) {

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupDetailResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupDetailResponseDto.java
@@ -1,0 +1,180 @@
+package com.example.muaring.domain.group.dto;
+
+import com.example.muaring.domain.common.ProfileStatus;
+import com.example.muaring.domain.group.entity.Group;
+import com.example.muaring.domain.group.entity.GroupCategory;
+import com.example.muaring.domain.group.entity.GroupMusicProfile;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupDetailResponseDto {
+
+    private Long groupId;
+    private Long adminUserId;
+    private String name;
+    private String description;
+    private Integer memberCount;
+    private Integer maxMembers;
+    private Boolean isPublic;
+    private Boolean isDeleted;
+    private LocalDateTime createdAt;
+    private LocalDateTime playlistUpdatedAt;
+
+    private List<CategoryDto> category;
+
+    private MusicProfileDto musicProfile;
+
+    // ---------- Factories ----------
+
+    /** 기본(라이트): status, updatedAt만 포함 */
+    public static GroupDetailResponseDto ofLight(
+            Group group,
+            int memberCount,
+            List<GroupCategory> categories,
+            GroupMusicProfile profile // null 가능
+    ) {
+        return baseBuilder(group, memberCount, categories)
+                .musicProfile(MusicProfileDto.ofHeader(profile))
+                .build();
+    }
+
+    /** 확장: metrics까지 포함 */
+    public static GroupDetailResponseDto ofWithMetrics(
+            Group group,
+            int memberCount,
+            List<GroupCategory> categories,
+            GroupMusicProfile profile // null 가능
+    ) {
+        return baseBuilder(group, memberCount, categories)
+                .musicProfile(MusicProfileDto.ofFull(profile))
+                .build();
+    }
+
+    // ---------- Internals ----------
+
+    private static GroupDetailResponseDtoBuilder baseBuilder(
+            Group group,
+            int memberCount,
+            List<GroupCategory> categories
+    ) {
+        return GroupDetailResponseDto.builder()
+                .groupId(group.getId())
+                .adminUserId(group.getAdmin().getId())
+                .name(group.getName())
+                .description(group.getDescription())
+                .memberCount(memberCount)
+                .maxMembers(group.getMaxMembers())
+                .isPublic(group.getIsPublic())
+                .isDeleted(group.getIsDeleted())
+                .createdAt(group.getCreatedAt())
+                .playlistUpdatedAt(group.getPlaylistUpdatedAt())
+                .category(toCategoryDtos(categories));
+    }
+
+    private static List<CategoryDto> toCategoryDtos(List<GroupCategory> categories) {
+        return categories == null ? List.of() :
+                categories.stream()
+                        .filter(Objects::nonNull)
+                        .map(c -> new CategoryDto(c.getId(), c.getName()))
+                        .collect(Collectors.toList());
+    }
+
+    // ---------- Nested DTOs ----------
+
+    @Getter
+    @AllArgsConstructor
+    public static class CategoryDto {
+        private Long groupCategoryId;
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MusicProfileDto {
+        private ProfileStatus status;          // NOT_AVAILABLE | PROCESSING | READY
+        private LocalDateTime updatedAt;       // 최신성 배지용
+        private Metrics metrics;               // ofFull에서만 채움 (라이트에선 null)
+
+        public static MusicProfileDto ofHeader(GroupMusicProfile p) {
+            if (p == null) {
+                return MusicProfileDto.builder()
+                        .status(ProfileStatus.NOT_AVAILABLE)
+                        .updatedAt(null)
+                        .metrics(null)
+                        .build();
+            }
+            return MusicProfileDto.builder()
+                    .status(p.getStatus())
+                    .updatedAt(p.getUpdatedAt())
+                    .metrics(null) // header only
+                    .build();
+        }
+
+        public static MusicProfileDto ofFull(GroupMusicProfile p) {
+            if (p == null) {
+                return ofHeader(null);
+            }
+            return MusicProfileDto.builder()
+                    .status(p.getStatus())
+                    .updatedAt(p.getUpdatedAt())
+                    .metrics(Metrics.from(p))
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Metrics {
+        private Double avgDanceability;
+        private Double avgEnergy;
+        private Double avgValence;
+        private Double avgAcousticness;
+        private Double avgInstrumentalness;
+        private Double avgSpeechiness;
+        private Double avgTempo;
+        private Double avgLoudness;
+        private Double avgPopularity;
+        private Double avgRarity;
+        private Double hiddenGemRatio;
+
+        private Integer totalSongs;
+        private Integer uniqueTracks;
+        private Integer genreDiversity;
+        private Double activeMemberRatio;
+        private Integer calculatedPeriodDays;
+
+        public static Metrics from(GroupMusicProfile p) {
+            if (p == null || p.getStatus() != ProfileStatus.READY) return null;
+            return Metrics.builder()
+                    .avgDanceability(p.getAvgDanceability())
+                    .avgEnergy(p.getAvgEnergy())
+                    .avgValence(p.getAvgValence())
+                    .avgAcousticness(p.getAvgAcousticness())
+                    .avgInstrumentalness(p.getAvgInstrumentalness())
+                    .avgSpeechiness(p.getAvgSpeechiness())
+                    .avgTempo(p.getAvgTempo())
+                    .avgLoudness(p.getAvgLoudness())
+                    .avgPopularity(p.getAvgPopularity())
+                    .avgRarity(p.getAvgRarity())
+                    .hiddenGemRatio(p.getHiddenGemRatio())
+                    .totalSongs(p.getTotalSongs())
+                    .uniqueTracks(p.getUniqueTracks())
+                    .genreDiversity(p.getGenreDiversity())
+                    .activeMemberRatio(p.getActiveMemberRatio())
+                    .calculatedPeriodDays(p.getCalculatedPeriodDays())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupListResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupListResponseDto.java
@@ -1,0 +1,78 @@
+package com.example.muaring.domain.group.dto;
+
+import com.example.muaring.domain.group.entity.Group;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class GroupListResponseDto {
+
+    private final Long totalCount;
+    private final List<GroupSummaryDto> groups;
+
+    @Builder
+    public GroupListResponseDto(Long totalCount, List<GroupSummaryDto> groups) {
+        this.totalCount = totalCount;
+        this.groups = groups;
+    }
+
+    // dto를 생성하는 메서드
+    public static GroupListResponseDto of(Long totalCount,
+                                          List<Group> groupEntities,
+                                          Map<Long, List<Long>> categoryIdsByGroup) {
+        List<GroupSummaryDto> summaries = groupEntities.stream()
+                .map(g -> GroupSummaryDto.of(
+                        g.getId(),
+                        g.getName(),
+                        g.getDescription(),
+                        /**
+                         * 카테고리 리스트를 만듦
+                         * 현재 그룹의 id에 해당하는 카테고리 리스트가 있으면 반환
+                         * 없으면 빈 리스트 반환
+                        */
+                        categoryIdsByGroup.getOrDefault(g.getId(), List.of()),
+                        g.getMemberCount(),
+                        g.getMaxMembers(),
+                        g.getIsPublic()
+                ))
+                .toList();
+
+        return GroupListResponseDto.builder()
+                .totalCount(totalCount)
+                .groups(summaries)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class GroupSummaryDto {
+        private final Long groupId;
+        private final String name;
+        private final String description;
+        private final List<Long> groupCategoryIds;
+        private final int memberCount;
+        private final int maxMembers;
+        private final Boolean isPublic;
+
+        public static GroupSummaryDto of(Long groupId,
+                                         String name,
+                                         String description,
+                                         List<Long> groupCategoryIds,
+                                         int memberCount,
+                                         int maxMembers,
+                                         Boolean isPublic) {
+            return GroupSummaryDto.builder()
+                    .groupId(groupId)
+                    .name(name)
+                    .description(description)
+                    .groupCategoryIds(groupCategoryIds)
+                    .memberCount(memberCount)
+                    .maxMembers(maxMembers)
+                    .isPublic(isPublic)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/dto/MyGroupListResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/MyGroupListResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.muaring.domain.group.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyGroupListResponseDto {
+    private Long totalCount;
+    private List<MyGroupSummaryDto> groups;
+
+    public static MyGroupListResponseDto of(List<MyGroupSummaryDto> groups) {
+        return MyGroupListResponseDto.builder()
+                .totalCount((long) groups.size())
+                .groups(groups)
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/muaring/domain/group/dto/MyGroupSummaryDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/MyGroupSummaryDto.java
@@ -1,0 +1,35 @@
+package com.example.muaring.domain.group.dto;
+
+import com.example.muaring.domain.group.entity.Group;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyGroupSummaryDto {
+    private Long groupId;
+    private String name;
+    private String description;
+    private Integer memberCount;
+    private Boolean isPublic;
+    private String myRole;
+    private LocalDateTime createdAt;
+
+    public static MyGroupSummaryDto of(Group group, String myRole) {
+        return MyGroupSummaryDto.builder()
+                .groupId(group.getId())
+                .name(group.getName())
+                .description(group.getDescription())
+                .memberCount(group.getMemberCount())
+                .isPublic(group.getIsPublic())
+                .myRole(myRole)
+                .createdAt(group.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/entity/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/Group.java
@@ -40,18 +40,18 @@ public class Group extends BaseEntity {
     private Integer maxMembers;
 
     @Column(name = "is_public", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
-    private Boolean opened = true;  // isPublic -> opened 로 변경
+    private Boolean isPublic = true;
 
     @Column(name = "playlist_updated_at")
     private LocalDateTime playlistUpdatedAt;
 
     @Builder
-    public Group(Member admin, String name, String description, Integer maxMembers, Boolean opened) {
+    public Group(Member admin, String name, String description, Integer maxMembers, Boolean isPublic) {
         this.admin = admin;
         this.name = name;
         this.description = description;
         this.memberCount = 1; // 그룹 생성 시 멤버 수는 1명
         this.maxMembers = maxMembers;
-        this.opened = opened;
+        this.isPublic = isPublic;
     }
 }

--- a/src/main/java/com/example/muaring/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/GroupMember.java
@@ -38,4 +38,11 @@ public class GroupMember extends BaseEntity {
         ADMIN,
         MEMBER
     }
+
+    @Builder
+    public GroupMember(Group group, Member member, GroupRole role) {
+        this.group = group;
+        this.member = member;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupCategoryMappingRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupCategoryMappingRepository.java
@@ -2,6 +2,20 @@ package com.example.muaring.domain.group.repository;
 
 import com.example.muaring.domain.group.entity.GroupCategoryMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface GroupCategoryMappingRepository extends JpaRepository<GroupCategoryMapping, Long> {
+
+    // 그룹 ID를 활용해 category ID들을 받아오는 쿼리
+    @Query("""
+        select gcm.group.id as groupId,
+               gcm.groupCategory.id as groupCategoryId
+        from GroupCategoryMapping gcm
+        where gcm.group.id in :groupIds
+    """)
+    List<GroupIdCategoryIdProjection> findPairsByGroupIds(@Param("groupIds") List<Long> groupIds);
+
 }

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupIdCategoryIdProjection.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupIdCategoryIdProjection.java
@@ -1,0 +1,6 @@
+package com.example.muaring.domain.group.repository;
+
+public interface GroupIdCategoryIdProjection {
+    Long getGroupId();
+    Long getGroupCategoryId();
+}

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
@@ -1,0 +1,16 @@
+package com.example.muaring.domain.group.repository;
+
+import com.example.muaring.domain.group.entity.GroupMember;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    @EntityGraph(attributePaths = { "group" })
+    List<GroupMember> findByMember_IdOrderByGroup_NameAsc(Long memberId);
+}

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupMusicProfileRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupMusicProfileRepository.java
@@ -1,9 +1,9 @@
 package com.example.muaring.domain.group.repository;
 
-import com.example.muaring.domain.group.entity.GroupCategory;
+import com.example.muaring.domain.group.entity.GroupMusicProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GroupCategoryRepository extends JpaRepository<GroupCategory, Long> {
+public interface GroupMusicProfileRepository extends JpaRepository<GroupMusicProfile, Long> {
 }

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupRepository.java
@@ -1,9 +1,57 @@
 package com.example.muaring.domain.group.repository;
 
 import com.example.muaring.domain.group.entity.Group;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    /** 검색어, 공개 여부, 카테고리를 필터링(옵션 필터)해서 처리하는 메서드
+     * -1) 공개 여부 필터: isPublic 파라미터가 null이면 둘 다 가져옴
+     * -2) 검색어 필터: name이 빈 문자열이면 검색어 조건 X (넣으면 name 기준 검색)
+     * -3) 카테고리 필터: categoryIds가 null이면 조건 X -> 매핑 테이블에 존재 여부 체크
+     */
+    @Query(
+            value = """
+            select g
+            from Group g
+            where (:isPublic is null or g.isPublic = :isPublic)
+              and (:name is null or :name = ''
+                   or lower(g.name) like lower(concat('%', :name, '%')))
+              and (coalesce(:categoryIds, null) is null
+                   or exists (
+                       select 1
+                       from GroupCategoryMapping m
+                       where m.group = g
+                         and m.groupCategory.id in :categoryIds
+                   ))
+            """,
+            countQuery = """
+            select count(g)
+            from Group g
+            where (:isPublic is null or g.isPublic = :isPublic)
+              and (:name is null or :name = ''
+                   or lower(g.name) like lower(concat('%', :name, '%')))
+              and (coalesce(:categoryIds, null) is null
+                   or exists (
+                       select 1
+                       from GroupCategoryMapping m
+                       where m.group = g
+                         and m.groupCategory.id in :categoryIds
+                   ))
+            """
+    )
+    Page<Group> search(
+            @Param("name") String name,
+            @Param("isPublic") Boolean isPublic,
+            @Param("categoryIds") List<Long> categoryIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -1,24 +1,24 @@
 package com.example.muaring.domain.group.service;
 
-import com.example.muaring.domain.group.dto.GroupCreateRequestDto;
-import com.example.muaring.domain.group.dto.GroupCreateResponseDto;
-import com.example.muaring.domain.group.entity.Group;
-import com.example.muaring.domain.group.entity.GroupCategory;
-import com.example.muaring.domain.group.entity.GroupCategoryMapping;
+import com.example.muaring.domain.group.dto.*;
+import com.example.muaring.domain.group.entity.*;
 import com.example.muaring.domain.group.exception.GroupErrorCode;
-import com.example.muaring.domain.group.repository.GroupCategoryMappingRepository;
-import com.example.muaring.domain.group.repository.GroupCategoryRepository;
-import com.example.muaring.domain.group.repository.GroupRepository;
+import com.example.muaring.domain.group.repository.*;
 import com.example.muaring.domain.group.response.GroupException;
 import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.member.exception.MemberException;
 import com.example.muaring.domain.member.repository.MemberRepository;
 import com.example.muaring.domain.member.response.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.example.muaring.domain.group.entity.GroupMember.GroupRole.ADMIN;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +28,8 @@ public class GroupService {
     private final GroupCategoryRepository groupCategoryRepository;
     private final GroupCategoryMappingRepository mappingRepository;
     private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupMusicProfileRepository groupMusicProfileRepository;
 
     // 그룹 생성
     @Transactional
@@ -42,16 +44,18 @@ public class GroupService {
             throw new GroupException(GroupErrorCode.CATEGORY_SELECTION_EXCEEDED);
         }
 
+        // 그룹 생성
         Group newGroup = Group.builder()
                 .admin(admin)
                 .name(requestDto.getName())
                 .description(requestDto.getDescription())
                 .maxMembers(requestDto.getMaxMembers())
-                .opened(requestDto.getOpened())
+                .isPublic(requestDto.getIsPublic())
                 .build();
 
-        groupRepository.save(newGroup);
+        newGroup = groupRepository.saveAndFlush(newGroup);
 
+        // 그룹-카테고리 관계 생성
         for (Long categoryId : groupCategoryIds) {
             GroupCategory groupCategory = groupCategoryRepository.findById(categoryId)
                     .orElseThrow(() -> new GroupException(GroupErrorCode.CATEGORY_NOT_FOUND));
@@ -64,7 +68,86 @@ public class GroupService {
             mappingRepository.save(mapping);
         }
 
+        // 그룹-멤버 관계 생성
+        GroupMember groupMember = GroupMember.builder()
+                .group(newGroup)
+                .member(admin)
+                .role(ADMIN)
+                .build();
+
+        groupMemberRepository.save(groupMember);
+
+        // 그룹-음악 성향 생성
+        GroupMusicProfile profile = GroupMusicProfile.createEmpty(newGroup);
+        groupMusicProfileRepository.save(profile);
+
         return GroupCreateResponseDto.from(newGroup, groupCategoryIds);
     }
+
+    // 각 조건에 따라 그룹을 조회할 수 있는 메서드
+    @Transactional
+    public GroupListResponseDto getGroups(
+            String name,            // 검색어
+            Boolean isPublic,       // 공개 여부
+            List<Long> categoryIds, // 카테고리 필터
+            int page,               // 페이지 번호
+            int size,               // 페이지 크기
+            Sort sort               // 정렬 조건
+    ) {
+        Pageable pageable = PageRequest.of(page, size, sort);   // 0-based
+
+        // 빈 리스트일 경우, categoryIds를 null로 변경 (IN () 방지)
+        List<Long> normalizedCategoryIds =
+                (categoryIds == null || categoryIds.isEmpty()) ? null : categoryIds;
+
+        // Repository 단 페이지네이션 조회
+        Page<Group> groupPage = groupRepository.search(name, isPublic, categoryIds, pageable);
+        List<Group> groups = groupPage.getContent();    // 컨텐츠 받아오기
+
+        // 결과가 비어있으면 빈 DTO 반환
+        if (groups.isEmpty()) {
+            return GroupListResponseDto.builder()
+                    .totalCount(0L)
+                    .groups(List.of())
+                    .build();
+        }
+
+        // 그룹 id 리스트
+        List<Long> groupIds = groups.stream()
+                .map(Group::getId)
+                .toList();
+
+
+        // 매핑 테이블 한 번에 조회 → Map<groupId, List<categoryId>> 형태로 변환
+        Map<Long, List<Long>> categoryIdsByGroup = mappingRepository.findPairsByGroupIds(groupIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        GroupIdCategoryIdProjection::getGroupId,
+                        Collectors.mapping(GroupIdCategoryIdProjection::getGroupCategoryId, Collectors.toList())
+                ));
+
+        // DTO 조립
+        return GroupListResponseDto.of(
+                groupPage.getTotalElements(),   // 전체 개수
+                groups,                         // 현재 페이지 그룹 리스트
+                categoryIdsByGroup              // 그룹별 카테고리 매핑
+        );
+    }
+
+    // 내 소속 그룹 조회 메서드
+    @Transactional
+    public MyGroupListResponseDto getMyGroups(Long memberId) {
+        List<MyGroupSummaryDto> groups = groupMemberRepository.findByMember_IdOrderByGroup_NameAsc(memberId)
+                .stream()
+                .map(tuple -> MyGroupSummaryDto.of(
+                        tuple.getGroup(),
+                        tuple.getRole().name()
+                ))
+                .toList();
+
+        return MyGroupListResponseDto.of(groups);
+    }
+
+    // 그룹 상세 조회 메서드
 
 }

--- a/src/main/java/com/example/muaring/domain/member/controller/MeController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MeController.java
@@ -1,0 +1,23 @@
+package com.example.muaring.domain.member.controller;
+
+import com.example.muaring.domain.group.dto.MyGroupListResponseDto;
+import com.example.muaring.domain.group.service.GroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/me")
+@RequiredArgsConstructor
+public class MeController {
+
+    private final GroupService groupService;
+
+    @GetMapping("/groups/{memberId}")
+    public ResponseEntity<MyGroupListResponseDto> getMyGroups(@PathVariable Long memberId) {
+        return ResponseEntity.ok(groupService.getMyGroups(memberId));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#9 

## ✨ 작업 내용
- 기존 그룹 생성 api 로직 리팩토링
- 공개 그룹 조회 api
- 이름 검색해 그룹 조회 api (공개 그룹 필터링도 가능)
- 내가 소속된 그룹 조회 api (사용자 기능 추가된 후 리팩토링 예정)

## 📸 스크린샷(선택)
X

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고: 내가 소속된 그룹 조회 시 지금 엔드포인트는 /me/groups/{memberId} 이나 추후 me/groups로 변경 예정