### PR TITLE
feat: 프로필 생성 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,12 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test'
 	// testImplementation 'org.springframework.security:spring-security-test'
 
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// DTO 검증
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// postgresql
 	runtimeOnly 'org.postgresql:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -60,8 +66,6 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/muaring/common/response/ApiResponse.java
+++ b/src/main/java/com/example/muaring/common/response/ApiResponse.java
@@ -28,11 +28,6 @@ public record ApiResponse<T>(int code, String message, T data) {
     }
 
     // ⚪ 실패 응답
-    public static <T> ApiResponse<T> fail(ErrorCode code) {
-        return new ApiResponse<>(code.getCode(), code.getMessage(), null);
-    }
-
-    // ⚪ 실패 응답 (필드별 오류 상세 정보가 필요한 경우)
     public static <T> ApiResponse<T> fail(ErrorCode code, T data) {
         return new ApiResponse<>(code.getCode(), code.getMessage(), data);
     }

--- a/src/main/java/com/example/muaring/common/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/muaring/common/response/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, null));
     }
 
     // ⚪ 요청 헤더 누락 예외 처리
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleMissingHeader(MissingRequestHeaderException e) {
         ErrorCode errorCode = CommonErrorCode.REQUEST_HEADER_EMPTY;
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, null));
     }
 
     // ⚪ 지원하지 않는 HTTP 메서드 예외 처리
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(Exception e) {
         ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, null));
     }
 
     // ⚪ 잘못된 URL 접근 예외 처리
@@ -52,7 +52,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleNoHandlerFound(NoHandlerFoundException e) {
         ErrorCode errorCode = CommonErrorCode.NOT_FOUND_URL;
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, null));
     }
 
     // ⚪ DTO Validation 예외 처리
@@ -81,7 +81,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException e) {
         ErrorCode errorCode = CommonErrorCode.HTTP_MEDIA_TYPE_NOT_ACCEPTABLE;
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, null));
     }
 
     // ⚪ 그 외의 예외 처리
@@ -90,6 +90,6 @@ public class GlobalExceptionHandler {
         log.error("예상치 못한 예외가 발생했습니다.", e);
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, null));
     }
 }

--- a/src/main/java/com/example/muaring/config/DefaultImageInitializer.java
+++ b/src/main/java/com/example/muaring/config/DefaultImageInitializer.java
@@ -1,0 +1,43 @@
+package com.example.muaring.config;
+
+import com.example.muaring.domain.file.entity.Image;
+import com.example.muaring.domain.file.entity.ImageType;
+import com.example.muaring.domain.file.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DefaultImageInitializer {
+
+    private final ImageRepository imageRepository;
+    private final ImageProperties imageProperties;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void init() {
+        ImageProperties.DefaultImageProperties profileImage = imageProperties.defaultProfile();
+
+        boolean exists = imageRepository.findByImageTypeAndS3Key(ImageType.MEMBER, profileImage.s3Key()).isPresent();
+        if (exists) {
+            log.info("✅ 회원 프로필 기본 이미지가 이미 존재합니다.");
+            return;
+        }
+
+        Image defaultMemberImage = Image.create(
+                profileImage.fileName(),
+                profileImage.fileType(),
+                ImageType.MEMBER,
+                profileImage.s3Key(),
+                profileImage.fileSize()
+        );
+
+        imageRepository.save(defaultMemberImage);
+        log.info("✅ 회원 프로필 기본 이미지가 생성되었습니다: {}", defaultMemberImage.getS3Key());
+    }
+}

--- a/src/main/java/com/example/muaring/config/ImageProperties.java
+++ b/src/main/java/com/example/muaring/config/ImageProperties.java
@@ -1,0 +1,13 @@
+package com.example.muaring.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.image")
+public record ImageProperties(DefaultImageProperties defaultProfile) {
+    public record DefaultImageProperties(
+            String s3Key,
+            String fileName,
+            String fileType,
+            Long fileSize
+    ) {}
+}

--- a/src/main/java/com/example/muaring/config/JacksonConfig.java
+++ b/src/main/java/com/example/muaring/config/JacksonConfig.java
@@ -1,0 +1,22 @@
+package com.example.muaring.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> builder
+                // 빈 문자열("")을 null로 취급 → enum 역직렬화 시 예외 방지
+                .featuresToEnable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+                // 모르는 필드 무시하고 매핑 가능한 값만 채움
+                .featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                // JSON 직렬화 시 null 필드 제외 (응답 깔끔하게)
+                .serializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+}

--- a/src/main/java/com/example/muaring/config/S3Config.java
+++ b/src/main/java/com/example/muaring/config/S3Config.java
@@ -7,10 +7,11 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
-@EnableConfigurationProperties({S3Properties.class, FilePolicyProperties.class})
+@EnableConfigurationProperties({S3Properties.class, FilePolicyProperties.class, ImageProperties.class})
 @RequiredArgsConstructor
 public class S3Config {
 
@@ -26,6 +27,19 @@ public class S3Config {
         return S3Presigner.builder()
                 .region(Region.of(s3Properties.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+
+    @Bean(destroyMethod = "close")
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                s3Properties.s3().credentials().accessKey(),
+                s3Properties.s3().credentials().secretKey()
+        );
+
+        return S3Client.builder()
+                .region(Region.of(s3Properties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();
     }
 }

--- a/src/main/java/com/example/muaring/config/S3Properties.java
+++ b/src/main/java/com/example/muaring/config/S3Properties.java
@@ -14,5 +14,8 @@ public record S3Properties (
     ) {
         public record Presign(Integer uploadExpMinutes, Integer downloadExpMinutes) {}
         public record Credentials(String accessKey, String secretKey) {}
+        public String bucketUrl(String region) {
+            return "https://" + bucket + ".s3." + region + ".amazonaws.com";
+        }
     }
 }

--- a/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
         log.info("카카오 로그인 요청 수신");
         LoginResponseDTO response = kakaoAuthService.login(socialLoginRequestDTO.code(), socialLoginRequestDTO.authProvider());
         return ResponseEntity
-                .status(HttpStatus.CREATED)
+                .status(HttpStatus.OK)
                 .body(ApiResponse.ok(response, socialLoginRequestDTO.authProvider() + "로그인에 성공했습니다."));
     }
 }

--- a/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
+++ b/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
@@ -11,13 +11,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/image")
+@RequestMapping("/images")
 @RequiredArgsConstructor
 public class ImageController {
 
     private final ImageService imageService;
 
-    // 파일 업로드용 presigned URL 발급 API
+    // ⚪ 파일 업로드용 presigned URL 발급 API
     @PostMapping("/upload-presigned-url")
     @Operation(summary = "파일 업로드용 presigned URL 발급", description = "파일 업로드용 presigned URL 발급입니다.")
     public ResponseEntity<ApiResponse<PresignedUrlResponseDTO>> generateUploadPresignedUrl(
@@ -29,7 +29,7 @@ public class ImageController {
         );
     }
 
-    // 파일 다운로드용 presigned URL 발급 API
+    // ⚪ 파일 다운로드용 presigned URL 발급 API
     @PostMapping("/{imageId}/download-presigned-url")
     @Operation(summary = "파일 다운로드용 presigned URL 발급", description = "파일 다운로드용 presigned URL 발급입니다.")
     public ResponseEntity<ApiResponse<PresignedUrlResponseDTO>> generateDownloadPresignedUrl(@PathVariable Long imageId) {

--- a/src/main/java/com/example/muaring/domain/file/dto/ImageResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/ImageResponseDTO.java
@@ -1,0 +1,26 @@
+package com.example.muaring.domain.file.dto;
+
+import com.example.muaring.domain.file.entity.Image;
+import com.example.muaring.domain.file.entity.ImageType;
+
+public record ImageResponseDTO(
+        Long id,
+        String fileName,
+        String fileType,
+        ImageType imageType,
+        String imageUrl,
+        Long fileSize
+) {
+    public static ImageResponseDTO of(Image image, String bucketUrl) {
+        if (image == null) return null;
+        String url = bucketUrl + "/" + image.getS3Key();
+        return new ImageResponseDTO(
+                image.getId(),
+                image.getFileName(),
+                image.getFileType(),
+                image.getImageType(),
+                url,
+                image.getFileSize()
+        );
+    }
+}

--- a/src/main/java/com/example/muaring/domain/file/repository/ImageRepository.java
+++ b/src/main/java/com/example/muaring/domain/file/repository/ImageRepository.java
@@ -1,9 +1,13 @@
 package com.example.muaring.domain.file.repository;
 
 import com.example.muaring.domain.file.entity.Image;
+import com.example.muaring.domain.file.entity.ImageType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image,Long> {
+
+    Optional<Image> findByImageTypeAndS3Key(ImageType imageType, String s3Key);
 }

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -12,11 +12,11 @@ import com.example.muaring.domain.file.validator.FileValidator;
 import com.example.muaring.domain.group.entity.Group;
 import com.example.muaring.domain.group.repository.GroupRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -28,10 +28,12 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class ImageService {
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
     private final S3Properties s3Properties;
     private final ImageRepository imageRepository;
     private final FileValidator fileValidator;
@@ -92,14 +94,6 @@ public class ImageService {
 
         URL presignedUrl = s3Presigner.presignPutObject(putObjectPresignRequest).url();
 
-//        // image DB에 메타데이터 저장은 실제 프로필 수정 등에서 구현할 예정
-//        imageRepository.save(Image.create(
-//                request.fileName(),
-//                request.fileType(),
-//                request.imageType(),
-//                s3Key,
-//                request.fileSize()));
-
         return PresignedUrlResponseDTO.of(
                 presignedUrl.toString(),
                 s3Key
@@ -139,5 +133,21 @@ public class ImageService {
                 .replaceAll("[^a-zA-Z0-9._-]", "_")
                 .replaceAll("_+", "_")
                 .substring(0, Math.min(fileName.length(), 100));
+    }
+
+    // ⚪ 업로드된 s3 파일을 삭제하는 메서드
+    public void deleteObject(String s3Key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(s3Properties.s3().bucket())
+                    .key(s3Key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("✅ S3 객체 삭제를 완료했습니다.");
+        } catch (S3Exception e) {
+            log.error("❌ S3 객체 삭제 도중 문제가 발생했습니다.: {}", s3Key, e);
+            throw new RuntimeException("❌ S3 객체 삭제 도중 문제가 발생했습니다." + s3Key, e);
+        }
     }
 }

--- a/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.example.muaring.domain.member.controller;
+
+import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
+import com.example.muaring.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> checkNicknameDuplicated(@RequestParam("nickname") String nickname) {
+        NicknameCheckResponseDTO response = memberService.checkNicknameDuplicated(nickname);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(response, "닉네임 중복체크가 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
@@ -1,15 +1,15 @@
 package com.example.muaring.domain.member.controller;
 
 import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.domain.member.dto.request.MemberProfileCreateRequestDTO;
+import com.example.muaring.domain.member.dto.response.MemberProfileResponseDTO;
 import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
 import com.example.muaring.domain.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/members")
@@ -18,11 +18,23 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // 닉네임 중복 체크
     @GetMapping("/check-nickname")
     public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> checkNicknameDuplicated(@RequestParam("nickname") String nickname) {
         NicknameCheckResponseDTO response = memberService.checkNicknameDuplicated(nickname);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok(response, "닉네임 중복체크가 완료되었습니다."));
+    }
+
+    // 프로필 등록 (최초)
+    @PostMapping("/profile")
+    public ResponseEntity<ApiResponse<MemberProfileResponseDTO>> updateProfile(
+            @Valid @RequestBody MemberProfileCreateRequestDTO requestDTO
+    ) {
+        MemberProfileResponseDTO responseDTO = memberService.registerProfile(requestDTO);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(responseDTO, "프로필이 생성되었습니다."));
     }
 }

--- a/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
@@ -6,21 +6,27 @@ import com.example.muaring.domain.member.dto.response.MemberProfileResponseDTO;
 import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
 import com.example.muaring.domain.member.service.MemberService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
+@Validated
 public class MemberController {
 
     private final MemberService memberService;
 
     // 닉네임 중복 체크
     @GetMapping("/check-nickname")
-    public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> checkNicknameDuplicated(@RequestParam("nickname") String nickname) {
+    public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> checkNicknameDuplicated(
+            @RequestParam("nickname")
+            @NotBlank(message = "낙네임 입력은 필수입니다.")
+            String nickname) {
         NicknameCheckResponseDTO response = memberService.checkNicknameDuplicated(nickname);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileCreateRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileCreateRequestDTO.java
@@ -2,9 +2,11 @@ package com.example.muaring.domain.member.dto.request;
 
 import com.example.muaring.domain.file.entity.ImageType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record MemberProfileCreateRequestDTO(
         @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
         String nickname,
         String fileName,
         String fileType,

--- a/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileCreateRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileCreateRequestDTO.java
@@ -1,0 +1,14 @@
+package com.example.muaring.domain.member.dto.request;
+
+import com.example.muaring.domain.file.entity.ImageType;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberProfileCreateRequestDTO(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname,
+        String fileName,
+        String fileType,
+        ImageType imageType,
+        String s3Key,
+        Long fileSize
+) { }

--- a/src/main/java/com/example/muaring/domain/member/dto/response/MemberProfileResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/response/MemberProfileResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.muaring.domain.member.dto.response;
+
+import com.example.muaring.domain.file.dto.ImageResponseDTO;
+import com.example.muaring.domain.member.entity.Member;
+
+public record MemberProfileResponseDTO(
+        Long memberId,
+        String nickname,
+        ImageResponseDTO image
+) {
+    public static MemberProfileResponseDTO of(Member member, String bucketUrl) {
+        return new  MemberProfileResponseDTO(
+                member.getId(),
+                member.getNickname(),
+                ImageResponseDTO.of(member.getProfileImage(), bucketUrl)
+        );
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/dto/response/NicknameCheckResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/response/NicknameCheckResponseDTO.java
@@ -1,0 +1,10 @@
+package com.example.muaring.domain.member.dto.response;
+
+public record NicknameCheckResponseDTO(
+        String nickname,
+        boolean isDuplicated
+) {
+    public static NicknameCheckResponseDTO of(String nickname, boolean isDuplicated) {
+        return new NicknameCheckResponseDTO(nickname, isDuplicated);
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -58,6 +58,12 @@ public class Member extends BaseEntity {
     }
 
     public void updateProfile(String nickname, Image image) {
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new IllegalArgumentException("닉네임은 필수입니다.");
+        }
+        if (nickname.length() > 10) {
+            throw new IllegalArgumentException("닉네임은 10자를 초과할 수 없습니다.");
+        }
         this.nickname = nickname;
         this.profileImage = image;
     }

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -56,4 +56,9 @@ public class Member extends BaseEntity {
         member.email = email;
         return member;
     }
+
+    public void updateProfile(String nickname, Image image) {
+        this.nickname = nickname;
+        this.profileImage = image;
+    }
 }

--- a/src/main/java/com/example/muaring/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/member/repository/MemberRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+    boolean existsByNicknameAndIsDeletedFalse(String nickname);
 }

--- a/src/main/java/com/example/muaring/domain/member/response/MemberErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/member/response/MemberErrorCode.java
@@ -9,10 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
-    // 404 에러
-    MEMBER_NOT_FOUND(2001, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    // 400
+    ALREADY_HAS_PROFILE(2001, HttpStatus.BAD_REQUEST, "이미 프로필 정보가 존재하는 회원입니다."),
 
     // 404 에러
+    MEMBER_NOT_FOUND(2001, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     METRICS_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "핵심 필드를 찾을 수 없습니다."),
 
     // 409 에러

--- a/src/main/java/com/example/muaring/domain/member/response/MemberErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/member/response/MemberErrorCode.java
@@ -13,11 +13,11 @@ public enum MemberErrorCode implements ErrorCode {
     ALREADY_HAS_PROFILE(2001, HttpStatus.BAD_REQUEST, "이미 프로필 정보가 존재하는 회원입니다."),
 
     // 404 에러
-    MEMBER_NOT_FOUND(2001, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    METRICS_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "핵심 필드를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    METRICS_NOT_FOUND(2003, HttpStatus.NOT_FOUND, "핵심 필드를 찾을 수 없습니다."),
 
     // 409 에러
-    METRICS_CONFLICT(2003, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다.");
+    METRICS_CONFLICT(2004, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package com.example.muaring.domain.member.service;
+
+import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
+import com.example.muaring.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public NicknameCheckResponseDTO checkNicknameDuplicated(String nickname) {
+        boolean isDuplicated = memberRepository.existsByNicknameAndIsDeletedFalse(nickname);
+        return NicknameCheckResponseDTO.of(nickname, isDuplicated);
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -66,7 +66,7 @@ public class MemberService {
 
     private Image createImage(MemberProfileCreateRequestDTO requestDTO) {
         // 이미지를 선택하지 않은 경우 기본 이미지 반환
-        if (requestDTO.s3Key() == null | requestDTO.s3Key().isBlank()) {
+        if (requestDTO.s3Key() == null || requestDTO.s3Key().isEmpty()) {
             ImageProperties.DefaultImageProperties defaultProfileImage = imageProperties.defaultProfile();
             return imageRepository.findByImageTypeAndS3Key(ImageType.MEMBER, defaultProfileImage.s3Key())
                     .orElseThrow(() -> new FileException(FileErrorCode.IMAGE_NOT_FOUND));

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -1,20 +1,85 @@
 package com.example.muaring.domain.member.service;
 
+import com.example.muaring.common.security.SecurityUtil;
+import com.example.muaring.config.ImageProperties;
+import com.example.muaring.config.S3Properties;
+import com.example.muaring.domain.file.entity.ImageType;
+import com.example.muaring.domain.file.exception.FileErrorCode;
+import com.example.muaring.domain.file.exception.FileException;
+import com.example.muaring.domain.file.repository.ImageRepository;
+import com.example.muaring.domain.file.service.ImageService;
+import com.example.muaring.domain.member.dto.request.MemberProfileCreateRequestDTO;
+import com.example.muaring.domain.member.dto.response.MemberProfileResponseDTO;
 import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
+import com.example.muaring.domain.member.entity.Member;
+import com.example.muaring.domain.file.entity.Image;
+import com.example.muaring.domain.member.exception.MemberException;
 import com.example.muaring.domain.member.repository.MemberRepository;
+import com.example.muaring.domain.member.response.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final ImageRepository imageRepository;
+    private final ImageService imageService;
+    private final S3Properties s3Properties;
+    private final ImageProperties imageProperties;
 
     public NicknameCheckResponseDTO checkNicknameDuplicated(String nickname) {
         boolean isDuplicated = memberRepository.existsByNicknameAndIsDeletedFalse(nickname);
         return NicknameCheckResponseDTO.of(nickname, isDuplicated);
+    }
+
+    @Transactional
+    public MemberProfileResponseDTO registerProfile(MemberProfileCreateRequestDTO requestDTO) {
+        String s3Key = requestDTO.s3Key();
+
+        try {
+            Long memberId = SecurityUtil.getMemberId();
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            if (member.getNickname() != null) {
+                throw new MemberException(MemberErrorCode.ALREADY_HAS_PROFILE);
+            }
+
+            Image image = createImage(requestDTO);
+
+            member.updateProfile(requestDTO.nickname(), image);
+            return MemberProfileResponseDTO.of(member, s3Properties.s3().bucketUrl(s3Properties.region()));
+        } catch (Exception e) {
+            if (s3Key != null && !s3Key.isBlank()) {
+                log.warn("❌ 프로필 정보 생성 도중 문제가 발생했습니다.");
+                imageService.deleteObject(s3Key);
+            }
+            throw e;
+        }
+    }
+
+    private Image createImage(MemberProfileCreateRequestDTO requestDTO) {
+        // 이미지를 선택하지 않은 경우 기본 이미지 반환
+        if (requestDTO.s3Key() == null | requestDTO.s3Key().isBlank()) {
+            ImageProperties.DefaultImageProperties defaultProfileImage = imageProperties.defaultProfile();
+            return imageRepository.findByImageTypeAndS3Key(ImageType.MEMBER, defaultProfileImage.s3Key())
+                    .orElseThrow(() -> new FileException(FileErrorCode.IMAGE_NOT_FOUND));
+        }
+
+        // 이미지를 선택한 경우 presigned 업로드 이미지 메타데이터 생성
+        Image image = Image.create(
+                requestDTO.fileName(),
+                requestDTO.fileType(),
+                ImageType.MEMBER,
+                requestDTO.s3Key(),
+                requestDTO.fileSize()
+        );
+        return imageRepository.save(image);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,12 +21,24 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
 
+  jackson:
+    deserialization:
+      ACCEPT_EMPTY_STRING_AS_NULL_OBJECT: true  # 빈 문자열을 null으로 변환해준다.
+
 app:
   jwt:
     secret: ${JWT_SECRET}
     issuer: muaring
     access-ttl-seconds: 3600  # 1시간
     refresh-ttl-seconds: 604800  # 7일
+
+  image:
+    default-profile:
+      s3-key: public/default-profile-image.png
+      file-name: default-profile-image.png
+      file-type: image/png
+      file-size: 32768
+
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,6 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
 
-  jackson:
-    deserialization:
-      ACCEPT_EMPTY_STRING_AS_NULL_OBJECT: true  # 빈 문자열을 null으로 변환해준다.
-
 app:
   jwt:
     secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 관련 이슈
closed #27

## ✨ 작업 내용
닉네임 중복 검증 API와 프로필 생성 API를 구현했습니다.
프로필 생성의 경우는 이미지를 선택하지 않을 경우 디폴트 이미지가 들어갑니다.

## 📸 스크린샷(선택)
1. 이미지 선택 안했을시
<img width="734" height="558" alt="image" src="https://github.com/user-attachments/assets/baf144a3-9da5-4970-8fc2-654298295741" />

2. 이미지 선택했을시
<img width="478" height="562" alt="image" src="https://github.com/user-attachments/assets/33c5e021-ea94-4259-9bf8-b1481d0bf4ba" />

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
참고, 논의할 사항이 있다면 적어주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원 프로필 등록 및 수정 기능 추가
  * 닉네임 중복 여부 확인 기능 추가
  * 이미지 삭제 기능 추가
  * 기본 프로필 이미지 자동 초기화 기능 추가

* **Bug Fixes**
  * 로그인 응답 상태 코드 정정 (201 → 200)

* **Chores**
  * 이미지 관리 API 경로 개선
  * 에러 응답 처리 방식 표준화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->