### PR TITLE
Revert "refactor: 그룹 삭제 API를 soft delete로 수정", feat: 그룹 추방 API 추가

### DIFF
--- a/src/main/java/com/example/muaring/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/muaring/domain/common/BaseEntity.java
@@ -25,14 +25,4 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
 
     private LocalDateTime deletedAt;
-
-    protected void markDeleted() {
-        this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
-    }
-
-    protected void restore() {
-        this.isDeleted = false;
-        this.deletedAt = null;
-    }
 }

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -11,7 +11,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -135,19 +134,5 @@ public class GroupController {
     }
 
 
-    // [DELETE] /groups/{groupId}/members/{expellerId}
-    // 그룹 멤버 추방
-    @DeleteMapping("/{groupId}/members/{expellerId}")
-    public ResponseEntity<ApiResponse<Void>> expelMember(
-            @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal,
-            @PathVariable Long expellerId) {
-
-        Long adminId = principal.getMemberId();
-        groupService.expelMember(groupId, adminId, expellerId);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ApiResponse.ok("그룹 멤버 추방을 완료했습니다."));
-    }
 
 }

--- a/src/main/java/com/example/muaring/domain/group/entity/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/Group.java
@@ -51,12 +51,6 @@ public class Group extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMember> groupMembers = new ArrayList<>();
 
-    public void softDelete() {
-        this.markDeleted();
-        // 연관된 GroupMember들도 함께 soft delete
-        this.groupMembers.forEach(GroupMember::softDelete);
-    }
-
     @Builder
     public Group(Member admin, String name, String description, Integer maxMembers, Boolean isPublic) {
         this.admin = admin;

--- a/src/main/java/com/example/muaring/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/GroupMember.java
@@ -5,8 +5,6 @@ import com.example.muaring.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(
         name = "group_member",
@@ -50,9 +48,5 @@ public class GroupMember extends BaseEntity {
 
     public void updateRole(GroupRole role) {
         this.role = role;
-    }
-
-    public void softDelete() {
-        this.markDeleted();
     }
 }

--- a/src/main/java/com/example/muaring/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/group/exception/GroupErrorCode.java
@@ -15,7 +15,6 @@ public enum GroupErrorCode implements ErrorCode {
     CATEGORY_MUST_BE_THREE(5007, HttpStatus.BAD_REQUEST, "카테고리는 정확히 3개를 선택해야 합니다."),
     MAX_MEMBERS_TOO_SMALL(5008, HttpStatus.BAD_REQUEST, "최대 인원은 현재 멤버 수보다 작을 수 없습니다."),
     CANNOT_TRANSFER_TO_SELF(5011, HttpStatus.BAD_REQUEST, "자기 자신에게 관리자 권한을 이양할 수 없습니다."),
-    CANNOT_EXPEL_SELF(5013, HttpStatus.BAD_REQUEST, "자기 자신을 추방할 수 없습니다."),
 
     // 403 에러
     NOT_GROUP_ADMIN(5009, HttpStatus.FORBIDDEN, "그룹 관리자만 수정할 수 있습니다."),
@@ -28,8 +27,7 @@ public enum GroupErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(5012, HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
 
     // 409 에러
-    METRICS_CONFLICT(5006, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다."),
-    ALREADY_EXPELLED_MEMBER(5014, HttpStatus.CONFLICT, "이미 추방된 멤버입니다.");
+    METRICS_CONFLICT(5006, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
@@ -4,7 +4,6 @@ import com.example.muaring.domain.group.entity.GroupMember;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,15 +13,11 @@ import java.util.Optional;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
     @EntityGraph(attributePaths = { "group" })
-    @Query("SELECT gm FROM GroupMember gm WHERE gm.member.id = :memberId AND gm.isDeleted = false ORDER BY gm.group.name ASC")
     List<GroupMember> findByMember_IdOrderByGroup_NameAsc(Long memberId);
 
-    @Query("SELECT gm FROM GroupMember gm WHERE gm.group.id = :groupId AND gm.isDeleted = false")
     List<GroupMember> findByGroupId(Long groupId);
 
-    @Query("SELECT CASE WHEN COUNT(gm) > 0 THEN true ELSE false END FROM GroupMember gm WHERE gm.group.id = :groupId AND gm.member.id = :memberId AND gm.isDeleted = false")
     boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 
-    @Query("SELECT gm FROM GroupMember gm WHERE gm.group.id = :groupId AND gm.member.id = :memberId AND gm.isDeleted = false")
     Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
@@ -23,8 +22,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             value = """
             select g
             from Group g
-            where g.isDeleted = false
-              and (:isPublic is null or g.isPublic = :isPublic)
+            where (:isPublic is null or g.isPublic = :isPublic)
               and (:name is null or :name = ''
                    or lower(g.name) like lower(concat('%', :name, '%')))
               and (coalesce(:categoryIds, null) is null
@@ -38,8 +36,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             countQuery = """
             select count(g)
             from Group g
-            where g.isDeleted = false
-              and (:isPublic is null or g.isPublic = :isPublic)
+            where (:isPublic is null or g.isPublic = :isPublic)
               and (:name is null or :name = ''
                    or lower(g.name) like lower(concat('%', :name, '%')))
               and (coalesce(:categoryIds, null) is null
@@ -57,8 +54,4 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             @Param("categoryIds") List<Long> categoryIds,
             Pageable pageable
     );
-
-    // id로 검색할 때, 삭제되지 않은 그룹만 반환
-    @Query("SELECT g FROM Group g WHERE g.id = :id AND g.isDeleted = false")
-    Optional<Group> findById(@Param("id") Long id);
 }

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -228,7 +228,6 @@ public class GroupService {
     }
 
     // 그룹 삭제 메서드
-    @Transactional
     public void deleteGroup(Long groupId, Long memberId) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
@@ -238,7 +237,7 @@ public class GroupService {
             throw new GroupException(GroupErrorCode.NOT_GROUP_ADMIN);
         }
 
-        group.softDelete();
+        groupRepository.delete(group);
     }
 
     // 그룹 탈퇴 메서드
@@ -290,37 +289,4 @@ public class GroupService {
         // 그룹 멤버 수 감소
         group.decrementMemberCount();
     }
-
-    // 그룹 멤버 추방 메서드
-    @Transactional
-    public void expelMember(Long groupId, Long adminId, Long expellerId){
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
-
-        GroupMember adminMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, adminId)
-                .orElseThrow(() -> new GroupException(GroupErrorCode.NOT_GROUP_MEMBER));
-
-        if (adminMember.getRole() != ADMIN) {
-            throw new GroupException(GroupErrorCode.NOT_GROUP_ADMIN);
-        }
-
-        GroupMember expelMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, expellerId)
-                        .orElseThrow(() -> new GroupException(GroupErrorCode.NOT_GROUP_MEMBER));
-
-        // 자기 자신 추방 방지
-        if (adminId.equals(expellerId)) {
-            throw new GroupException(GroupErrorCode.CANNOT_EXPEL_SELF);
-        }
-
-        // 이미 삭제된 멤버인지 확인
-        if (expelMember.getIsDeleted()) {
-            throw new GroupException(GroupErrorCode.ALREADY_EXPELLED_MEMBER);
-        }
-
-        expelMember.softDelete();
-
-        // 그룹 멤버 수 감소
-        group.decrementMemberCount();
-    }
-
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련있는 이슈 번호(#000)을 적어주세요.
#19 


## ✨ 작업 내용
- 그룹 삭제 API를 soft delete로 수정
- soft delete 를 위해 BaseEntity에 markDeleted 메서드 추가
- GroupRepository, GroupMemberRepository 메서드들의 쿼리 조건에 isDeleted = false 를 추가
- 그룹 추방 API 추가


## 📸 스크린샷(선택)
X

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- BaseEntity의 isDeleted, deletedAt 컬럼을 protected로 수정했는데 문제가 있다면 말해주세요. -> private로 수정 후 따로 메서드 추가
- GroupRepository, GroupMemberRepository 메서드들의 쿼리 조건을 수정했으니까 담당자분들은 한번씩 확인해주세요!
- 그룹 추방 API 리뷰를 못 받았는데 머지해버려서 revert 하고 다시 pr 올립니다..
- Reverts MuAring/backend#39 