### PR TITLE
chore: GroupInviteToken 엔티티에 expiresAt 컬럼 추가, feat: 그룹 초대 관련 API 추가, fix: 그룹 추방 API, 그룹 삭제 soft delete API 추가

### DIFF
--- a/src/main/java/com/example/muaring/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/muaring/domain/common/BaseEntity.java
@@ -25,4 +25,14 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
 
     private LocalDateTime deletedAt;
+
+    protected void markDeleted() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    protected void restore() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -82,9 +82,8 @@ public class GroupController {
     // 그룹 멤버 목록 조회
     @GetMapping("/{groupId}/members")
     public ResponseEntity<ApiResponse<List<GroupMemberResponseDto>>> getGroupMembers(
-            @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal) {
-        Long memberId = principal.getMemberId();
+            @PathVariable Long groupId) {
+        Long memberId = SecurityUtil.getMemberId();
         List<GroupMemberResponseDto> members = groupService.getGroupMembers(groupId, memberId);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -97,9 +96,8 @@ public class GroupController {
     @PatchMapping("/{groupId}")
     public ResponseEntity<ApiResponse<GroupUpdateResponseDto>> updateGroup(
             @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal,
             @RequestBody GroupUpdateRequestDto request) {
-        Long memberId = principal.getMemberId();
+        Long memberId = SecurityUtil.getMemberId();
         GroupUpdateResponseDto response = groupService.updateGroup(groupId, memberId, request);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -113,9 +111,8 @@ public class GroupController {
     // 그룹 삭제
     @DeleteMapping("/{groupId}")
     public ResponseEntity<ApiResponse<Void>> deleteGroup(
-            @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal) {
-        Long memberId = principal.getMemberId();
+            @PathVariable Long groupId) {
+        Long memberId = SecurityUtil.getMemberId();
         groupService.deleteGroup(groupId, memberId);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -127,9 +124,8 @@ public class GroupController {
     // 그룹 탈퇴
     @DeleteMapping("/{groupId}/leave")
     public ResponseEntity<ApiResponse<Void>> leaveGroup(
-            @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal) {
-        Long memberId = principal.getMemberId();
+            @PathVariable Long groupId) {
+        Long memberId = SecurityUtil.getMemberId();
         groupService.leaveGroup(groupId, memberId);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -141,10 +137,9 @@ public class GroupController {
     @PostMapping("/{groupId}/admin-leave")
     public ResponseEntity<ApiResponse<Void>> adminLeaveGroup(
             @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal,
             @RequestBody AdminLeaveRequestDto request) {
 
-        Long memberId = principal.getMemberId();;
+        Long memberId = SecurityUtil.getMemberId();;
         groupService.adminLeaveGroup(groupId, memberId, request);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -156,10 +151,9 @@ public class GroupController {
     @DeleteMapping("/{groupId}/members/{expellerId}")
     public ResponseEntity<ApiResponse<Void>> expelMember(
             @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal,
             @PathVariable Long expellerId) {
 
-        Long adminId = principal.getMemberId();
+        Long adminId = SecurityUtil.getMemberId();
         groupService.expelMember(groupId, adminId, expellerId);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -151,6 +151,19 @@ public class GroupController {
                 .body(ApiResponse.ok("관리자 권한을 양도하고 그룹에서 탈퇴했습니다."));
     }
 
+    // [DELETE] /groups/{groupId}/members/{expellerId}
+    // 그룹 멤버 추방
+    @DeleteMapping("/{groupId}/members/{expellerId}")
+    public ResponseEntity<ApiResponse<Void>> expelMember(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @PathVariable Long expellerId) {
 
+        Long adminId = principal.getMemberId();
+        groupService.expelMember(groupId, adminId, expellerId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok("그룹 멤버 추방을 완료했습니다."));
+    }
 
 }

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupInviteController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupInviteController.java
@@ -1,0 +1,94 @@
+package com.example.muaring.domain.group.controller;
+
+import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.domain.auth.security.MemberPrincipal;
+import com.example.muaring.domain.group.dto.GroupInviteResponseDto;
+import com.example.muaring.domain.group.dto.InvitePreviewResponseDto;
+import com.example.muaring.domain.group.service.GroupInviteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups/{groupId}/invites")
+@RequiredArgsConstructor
+public class GroupInviteController {
+
+    private final GroupInviteService groupInviteService;
+
+    // 초대 링크 생성 (모든 그룹 멤버 가능)
+    @PostMapping
+    public ResponseEntity<ApiResponse<GroupInviteResponseDto>> createInviteToken(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal MemberPrincipal principal) {
+
+        GroupInviteResponseDto response = groupInviteService.createInviteToken(
+                groupId,
+                principal.getMemberId()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(response, "초대 링크가 생성되었습니다."));
+    }
+
+    // 활성화된 초대 링크 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GroupInviteResponseDto>>> getActiveInviteTokens(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal MemberPrincipal principal) {
+
+        List<GroupInviteResponseDto> response = groupInviteService.getActiveInviteTokens(
+                groupId,
+                principal.getMemberId()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(response));
+    }
+
+    // 초대 링크 삭제
+    @DeleteMapping("/{inviteId}")
+    public ResponseEntity<ApiResponse<Void>> deleteInviteToken(
+            @PathVariable Long groupId,
+            @PathVariable Long inviteId,
+            @AuthenticationPrincipal MemberPrincipal principal) {
+
+        groupInviteService.deleteInviteToken(groupId, inviteId, principal.getMemberId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok("초대 링크가 삭제되었습니다."));
+    }
+
+
+    // 초대 링크 미리보기
+    @GetMapping("/{inviteToken}")
+    public ResponseEntity<ApiResponse<InvitePreviewResponseDto>> getInvitePreview(
+            @PathVariable String inviteToken) {
+
+        InvitePreviewResponseDto response = groupInviteService.getInvitePreview(inviteToken);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(response));
+    }
+
+    // 초대 링크로 그룹 가입
+    @PostMapping("/{inviteToken}/join")
+    public ResponseEntity<ApiResponse<Void>> joinByInviteToken(
+            @PathVariable String inviteToken,
+            @AuthenticationPrincipal MemberPrincipal principal) {
+
+        groupInviteService.joinByInviteToken(inviteToken, principal.getMemberId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok("그룹에 가입되었습니다."));
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupInviteController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupInviteController.java
@@ -1,6 +1,7 @@
 package com.example.muaring.domain.group.controller;
 
 import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.common.security.SecurityUtil;
 import com.example.muaring.domain.auth.security.MemberPrincipal;
 import com.example.muaring.domain.group.dto.GroupInviteResponseDto;
 import com.example.muaring.domain.group.dto.InvitePreviewResponseDto;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Security;
 import java.util.List;
 
 @RestController
@@ -24,12 +26,11 @@ public class GroupInviteController {
     // 초대 링크 생성 (모든 그룹 멤버 가능)
     @PostMapping
     public ResponseEntity<ApiResponse<GroupInviteResponseDto>> createInviteToken(
-            @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal) {
+            @PathVariable Long groupId) {
 
         GroupInviteResponseDto response = groupInviteService.createInviteToken(
                 groupId,
-                principal.getMemberId()
+                SecurityUtil.getMemberId()
         );
 
         return ResponseEntity
@@ -41,12 +42,11 @@ public class GroupInviteController {
     // 활성화된 초대 링크 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<List<GroupInviteResponseDto>>> getActiveInviteTokens(
-            @PathVariable Long groupId,
-            @AuthenticationPrincipal MemberPrincipal principal) {
+            @PathVariable Long groupId) {
 
         List<GroupInviteResponseDto> response = groupInviteService.getActiveInviteTokens(
                 groupId,
-                principal.getMemberId()
+                SecurityUtil.getMemberId()
         );
 
         return ResponseEntity
@@ -59,10 +59,9 @@ public class GroupInviteController {
     @DeleteMapping("/{inviteId}")
     public ResponseEntity<ApiResponse<Void>> deleteInviteToken(
             @PathVariable Long groupId,
-            @PathVariable Long inviteId,
-            @AuthenticationPrincipal MemberPrincipal principal) {
+            @PathVariable Long inviteId) {
 
-        groupInviteService.deleteInviteToken(groupId, inviteId, principal.getMemberId());
+        groupInviteService.deleteInviteToken(groupId, inviteId, SecurityUtil.getMemberId());
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -87,10 +86,9 @@ public class GroupInviteController {
     // 초대 링크로 그룹 가입
     @PostMapping("/{inviteToken}/join")
     public ResponseEntity<ApiResponse<Void>> joinByInviteToken(
-            @PathVariable String inviteToken,
-            @AuthenticationPrincipal MemberPrincipal principal) {
+            @PathVariable String inviteToken) {
 
-        groupInviteService.joinByInviteToken(inviteToken, principal.getMemberId());
+        groupInviteService.joinByInviteToken(inviteToken, SecurityUtil.getMemberId());
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupInviteController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupInviteController.java
@@ -20,6 +20,7 @@ public class GroupInviteController {
 
     private final GroupInviteService groupInviteService;
 
+    // [POST] /groups/{groupId}/invites
     // 초대 링크 생성 (모든 그룹 멤버 가능)
     @PostMapping
     public ResponseEntity<ApiResponse<GroupInviteResponseDto>> createInviteToken(
@@ -36,6 +37,7 @@ public class GroupInviteController {
                 .body(ApiResponse.ok(response, "초대 링크가 생성되었습니다."));
     }
 
+    // [GET] /groups/{groupId}/invites
     // 활성화된 초대 링크 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<List<GroupInviteResponseDto>>> getActiveInviteTokens(
@@ -52,6 +54,7 @@ public class GroupInviteController {
                 .body(ApiResponse.ok(response));
     }
 
+    // [DELETE] /groups/{groupId}/invites/{inviteId}
     // 초대 링크 삭제
     @DeleteMapping("/{inviteId}")
     public ResponseEntity<ApiResponse<Void>> deleteInviteToken(
@@ -67,6 +70,7 @@ public class GroupInviteController {
     }
 
 
+    // [GET] /groups/{groupId}/invites/{inviteToken}
     // 초대 링크 미리보기
     @GetMapping("/{inviteToken}")
     public ResponseEntity<ApiResponse<InvitePreviewResponseDto>> getInvitePreview(
@@ -79,6 +83,7 @@ public class GroupInviteController {
                 .body(ApiResponse.ok(response));
     }
 
+    // [POST] /groups/{groupId}/invites/{inviteToken}/join
     // 초대 링크로 그룹 가입
     @PostMapping("/{inviteToken}/join")
     public ResponseEntity<ApiResponse<Void>> joinByInviteToken(

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupInviteResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupInviteResponseDto.java
@@ -14,7 +14,7 @@ public class GroupInviteResponseDto {
     private String inviteToken;
     private LocalDateTime createdAt;
     private LocalDateTime expiresAt;
-    private String createdByName;
+    private String inviterName;
 
     public static GroupInviteResponseDto from(GroupInviteToken token, String baseUrl) {
         return GroupInviteResponseDto.builder()
@@ -23,7 +23,7 @@ public class GroupInviteResponseDto {
                 .inviteToken(token.getInviteToken())
                 .createdAt(token.getCreatedAt())
                 .expiresAt(token.getExpiresAt())
-                .createdByName(token.getCreatedBy().getNickname())
+                .inviterName(token.getInviter().getNickname())
                 .build();
     }
 }

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupInviteResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupInviteResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.muaring.domain.group.dto;
+
+import com.example.muaring.domain.group.entity.GroupInviteToken;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GroupInviteResponseDto {
+    private Long inviteId;
+    private String inviteUrl;
+    private String inviteToken;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+    private String createdByName;
+
+    public static GroupInviteResponseDto from(GroupInviteToken token, String baseUrl) {
+        return GroupInviteResponseDto.builder()
+                .inviteId(token.getId())
+                .inviteUrl(baseUrl + "/invite/" + token.getInviteToken())
+                .inviteToken(token.getInviteToken())
+                .createdAt(token.getCreatedAt())
+                .expiresAt(token.getExpiresAt())
+                .createdByName(token.getCreatedBy().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/dto/InvitePreviewResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/InvitePreviewResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.muaring.domain.group.dto;
+
+import com.example.muaring.domain.group.entity.Group;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InvitePreviewResponseDto {
+    private Long groupId;
+    private String groupName;
+    private String groupDescription;
+    private String groupImage;
+    private Integer currentMembers;
+    private Integer maxMembers;
+    private Boolean isExpired;
+    private Boolean isUsable;
+
+    public static InvitePreviewResponseDto of(Group group, boolean isExpired, boolean isUsable) {
+        return InvitePreviewResponseDto.builder()
+                .groupId(group.getId())
+                .groupName(group.getName())
+                .groupDescription(group.getDescription())
+                .groupImage(group.getGroupImage())
+                .currentMembers(group.getMemberCount())
+                .maxMembers(group.getMaxMembers())
+                .isExpired(isExpired)
+                .isUsable(isUsable)
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/example/muaring/domain/group/entity/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/Group.java
@@ -61,6 +61,20 @@ public class Group extends BaseEntity {
         this.isPublic = isPublic;
     }
 
+    // 그룹 이미지 URL 반환
+    public String getGroupImage() {
+        if (image != null) {
+            return image.getUrl();
+        }
+        // 기본 이미지 반환
+        return "https://your-bucket.s3.amazonaws.com/default-group-image.png";
+    }
+
+    public boolean isFull() {
+        return memberCount >= maxMembers;
+    }
+
+
     public void updateDescription(String description) {
         this.description = description;
     }
@@ -73,11 +87,18 @@ public class Group extends BaseEntity {
         this.isPublic = isPublic;
     }
 
+    public void incrementMemberCount() {
+        this.memberCount++;
+    }
     public void decrementMemberCount() {
         this.memberCount--;
     }
 
     public void updateAdmin(Member admin) {
         this.admin = admin;
+    }
+
+    public void updateImage(Image image) {
+        this.image = image;
     }
 }

--- a/src/main/java/com/example/muaring/domain/group/entity/Group.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/Group.java
@@ -51,6 +51,12 @@ public class Group extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMember> groupMembers = new ArrayList<>();
 
+    public void softDelete() {
+        this.markDeleted();
+        // 연관된 GroupMember들도 함께 soft delete
+        this.groupMembers.forEach(GroupMember::softDelete);
+    }
+
     @Builder
     public Group(Member admin, String name, String description, Integer maxMembers, Boolean isPublic) {
         this.admin = admin;

--- a/src/main/java/com/example/muaring/domain/group/entity/GroupInviteToken.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/GroupInviteToken.java
@@ -29,8 +29,8 @@ public class GroupInviteToken extends BaseEntity {
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "created_by", nullable = false)
-    private Member createdBy;
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private Member inviter;
 
     @Column(name = "invite_token", length = 36, nullable = false, unique = true)
     private String inviteToken;
@@ -40,9 +40,9 @@ public class GroupInviteToken extends BaseEntity {
 
 
     @Builder
-    public GroupInviteToken(Group group, Member createdBy) {
+    public GroupInviteToken(Group group, Member inviter) {
         this.group = group;
-        this.createdBy = createdBy;
+        this.inviter = inviter;
         this.inviteToken = UUID.randomUUID().toString();
         this.expiresAt = LocalDateTime.now().plusDays(7);  // 기본 7일
     }

--- a/src/main/java/com/example/muaring/domain/group/entity/GroupInviteToken.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/GroupInviteToken.java
@@ -5,6 +5,8 @@ import com.example.muaring.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(
         name = "group_invite_token",
@@ -31,6 +33,10 @@ public class GroupInviteToken extends BaseEntity {
 
     @Column(name = "invite_token", length = 36, nullable = false, unique = true)
     private String inviteToken;
+
+    @Column(name="expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
 }
 
 

--- a/src/main/java/com/example/muaring/domain/group/entity/GroupInviteToken.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/GroupInviteToken.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(
@@ -28,8 +29,8 @@ public class GroupInviteToken extends BaseEntity {
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @JoinColumn(name = "created_by", nullable = false)
+    private Member createdBy;
 
     @Column(name = "invite_token", length = 36, nullable = false, unique = true)
     private String inviteToken;
@@ -37,6 +38,28 @@ public class GroupInviteToken extends BaseEntity {
     @Column(name="expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
+
+    @Builder
+    public GroupInviteToken(Group group, Member createdBy) {
+        this.group = group;
+        this.createdBy = createdBy;
+        this.inviteToken = UUID.randomUUID().toString();
+        this.expiresAt = LocalDateTime.now().plusDays(7);  // 기본 7일
+    }
+
+    // 만료 여부 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    // 사용 가능 여부 확인
+    public boolean isUsable() {
+        return !getIsDeleted() && !isExpired();
+    }
+
+    public void softDelete() {
+        this.markDeleted();
+    }
 }
 
 

--- a/src/main/java/com/example/muaring/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/example/muaring/domain/group/entity/GroupMember.java
@@ -49,4 +49,8 @@ public class GroupMember extends BaseEntity {
     public void updateRole(GroupRole role) {
         this.role = role;
     }
+
+    public void softDelete() {
+        this.markDeleted();
+    }
 }

--- a/src/main/java/com/example/muaring/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/group/exception/GroupErrorCode.java
@@ -15,19 +15,27 @@ public enum GroupErrorCode implements ErrorCode {
     CATEGORY_MUST_BE_THREE(5007, HttpStatus.BAD_REQUEST, "카테고리는 정확히 3개를 선택해야 합니다."),
     MAX_MEMBERS_TOO_SMALL(5008, HttpStatus.BAD_REQUEST, "최대 인원은 현재 멤버 수보다 작을 수 없습니다."),
     CANNOT_TRANSFER_TO_SELF(5011, HttpStatus.BAD_REQUEST, "자기 자신에게 관리자 권한을 이양할 수 없습니다."),
+    CANNOT_EXPEL_SELF(5013, HttpStatus.BAD_REQUEST, "자기 자신을 추방할 수 없습니다."),
+    INVITE_EXPIRED_OR_INVALID(5016, HttpStatus.BAD_REQUEST, "만료되었거나 유효하지 않은 초대 링크입니다."),
+    INVALID_INVITE(5017, HttpStatus.BAD_REQUEST, "유효하지 않은 초대 링크입니다."),
 
     // 403 에러
     NOT_GROUP_ADMIN(5009, HttpStatus.FORBIDDEN, "그룹 관리자만 수정할 수 있습니다."),
     NOT_GROUP_MEMBER(5010, HttpStatus.FORBIDDEN, "그룹 멤버만 조회할 수 있습니다."),
+    NOT_INVITE_CREATOR(5018, HttpStatus.FORBIDDEN, "초대 링크 생성자만 삭제할 수 있습니다."),
 
     // 404 에러
     GROUP_NOT_FOUND(5003, HttpStatus.NOT_FOUND, "해당 그룹을 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(5004, HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
     METRICS_NOT_FOUND(5005, HttpStatus.NOT_FOUND, "핵심 필드를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(5012, HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
+    INVITE_NOT_FOUND(5015, HttpStatus.NOT_FOUND, "초대 링크를 찾을 수 없습니다."),
 
     // 409 에러
-    METRICS_CONFLICT(5006, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다.");
+    METRICS_CONFLICT(5006, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다."),
+    ALREADY_EXPELLED_MEMBER(5014, HttpStatus.CONFLICT, "이미 추방된 멤버입니다."),
+    ALREADY_GROUP_MEMBER(5019, HttpStatus.CONFLICT, "이미 그룹 멤버입니다."),
+    GROUP_FULL(5020, HttpStatus.CONFLICT, "그룹 인원이 꽉 찼습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupInviteTokenRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupInviteTokenRepository.java
@@ -1,0 +1,33 @@
+package com.example.muaring.domain.group.repository;
+
+import com.example.muaring.domain.group.entity.GroupInviteToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupInviteTokenRepository extends JpaRepository<GroupInviteToken, Long> {
+
+    Optional<GroupInviteToken> findByInviteToken(String inviteToken);
+
+    // 그룹의 활성화된 초대 링크 목록 (삭제되지 않고 만료되지 않음)
+    @Query("SELECT git FROM GroupInviteToken git " +
+            "WHERE git.group.id = :groupId " +
+            "AND git.isDeleted = false " +
+            "AND git.expiresAt > :now " +
+            "ORDER BY git.createdAt DESC")
+    List<GroupInviteToken> findActiveTokensByGroupId(
+            @Param("groupId") Long groupId,
+            @Param("now") LocalDateTime now
+    );
+
+    // 특정 멤버가 생성한 초대 링크 목록
+    @Query("SELECT git FROM GroupInviteToken git " +
+            "WHERE git.createdBy.id = :memberId " +
+            "AND git.isDeleted = false " +
+            "ORDER BY git.createdAt DESC")
+    List<GroupInviteToken> findByCreatedById(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
@@ -4,6 +4,7 @@ import com.example.muaring.domain.group.entity.GroupMember;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,11 +14,15 @@ import java.util.Optional;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
     @EntityGraph(attributePaths = { "group" })
+    @Query("SELECT gm FROM GroupMember gm WHERE gm.member.id = :memberId AND gm.isDeleted = false ORDER BY gm.group.name ASC")
     List<GroupMember> findByMember_IdOrderByGroup_NameAsc(Long memberId);
 
+    @Query("SELECT gm FROM GroupMember gm WHERE gm.group.id = :groupId AND gm.isDeleted = false")
     List<GroupMember> findByGroupId(Long groupId);
 
+    @Query("SELECT CASE WHEN COUNT(gm) > 0 THEN true ELSE false END FROM GroupMember gm WHERE gm.group.id = :groupId AND gm.member.id = :memberId AND gm.isDeleted = false")
     boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 
+    @Query("SELECT gm FROM GroupMember gm WHERE gm.group.id = :groupId AND gm.member.id = :memberId AND gm.isDeleted = false")
     Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
@@ -22,7 +23,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             value = """
             select g
             from Group g
-            where (:isPublic is null or g.isPublic = :isPublic)
+            where g.isDeleted = false
+              and (:isPublic is null or g.isPublic = :isPublic)
               and (:name is null or :name = ''
                    or lower(g.name) like lower(concat('%', :name, '%')))
               and (coalesce(:categoryIds, null) is null
@@ -36,7 +38,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             countQuery = """
             select count(g)
             from Group g
-            where (:isPublic is null or g.isPublic = :isPublic)
+            where g.isDeleted = false
+              and (:isPublic is null or g.isPublic = :isPublic)
               and (:name is null or :name = ''
                    or lower(g.name) like lower(concat('%', :name, '%')))
               and (coalesce(:categoryIds, null) is null
@@ -54,4 +57,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             @Param("categoryIds") List<Long> categoryIds,
             Pageable pageable
     );
+
+    // id로 검색할 때, 삭제되지 않은 그룹만 반환
+    @Query("SELECT g FROM Group g WHERE g.id = :id AND g.isDeleted = false")
+    Optional<Group> findById(@Param("id") Long id);
 }

--- a/src/main/java/com/example/muaring/domain/group/service/GroupInviteService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupInviteService.java
@@ -1,0 +1,142 @@
+package com.example.muaring.domain.group.service;
+
+import com.example.muaring.domain.group.dto.GroupInviteResponseDto;
+import com.example.muaring.domain.group.dto.InvitePreviewResponseDto;
+import com.example.muaring.domain.group.entity.Group;
+import com.example.muaring.domain.group.entity.GroupInviteToken;
+import com.example.muaring.domain.group.entity.GroupMember;
+import com.example.muaring.domain.group.exception.GroupErrorCode;
+import com.example.muaring.domain.group.repository.GroupInviteTokenRepository;
+import com.example.muaring.domain.group.repository.GroupMemberRepository;
+import com.example.muaring.domain.group.repository.GroupRepository;
+import com.example.muaring.domain.group.response.GroupException;
+import com.example.muaring.domain.member.entity.Member;
+import com.example.muaring.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupInviteService {
+
+    private final GroupInviteTokenRepository inviteTokenRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${app.base-url}")
+    private String baseUrl;
+
+    // 초대 링크 생성
+    @Transactional
+    public GroupInviteResponseDto createInviteToken(Long groupId, Long memberId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository
+                .findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.NOT_GROUP_MEMBER));
+
+        // 초대 토큰 생성 (UUID로 생성, 우선 만료일 7일로 설정함)
+        GroupInviteToken inviteToken = GroupInviteToken.builder()
+                .group(group)
+                .createdBy(groupMember.getMember())
+                .build();
+
+        inviteTokenRepository.save(inviteToken);
+
+        return GroupInviteResponseDto.from(inviteToken, baseUrl);
+    }
+
+    // 그룹의 활성화된 초대 링크 목록 조회
+    public List<GroupInviteResponseDto> getActiveInviteTokens(Long groupId, Long memberId) {
+        if (!groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
+            throw new GroupException(GroupErrorCode.NOT_GROUP_MEMBER);
+        }
+
+        List<GroupInviteToken> tokens = inviteTokenRepository
+                .findActiveTokensByGroupId(groupId, LocalDateTime.now());
+
+        return tokens.stream()
+                .map(token -> GroupInviteResponseDto.from(token, baseUrl))
+                .toList();
+    }
+
+    // 초대 링크 정보 미리보기
+    public InvitePreviewResponseDto getInvitePreview(String inviteToken) {
+        GroupInviteToken token = inviteTokenRepository.findByInviteToken(inviteToken)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVITE_NOT_FOUND));
+
+        Group group = token.getGroup();
+
+        return InvitePreviewResponseDto.of(
+                group,
+                token.isExpired(),
+                token.isUsable()
+        );
+    }
+
+    // 초대 링크로 그룹 가입
+    @Transactional
+    public void joinByInviteToken(String inviteToken, Long memberId) {
+        GroupInviteToken token = inviteTokenRepository.findByInviteToken(inviteToken)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVITE_NOT_FOUND));
+
+        if (!token.isUsable()) {
+            throw new GroupException(GroupErrorCode.INVITE_EXPIRED_OR_INVALID);
+        }
+
+        Group group = token.getGroup();
+
+        // 이미 그룹 멤버인지 확인
+        if (groupMemberRepository.existsByGroupIdAndMemberId(group.getId(), memberId)) {
+            throw new GroupException(GroupErrorCode.ALREADY_GROUP_MEMBER);
+        }
+
+        // 그룹이 꽉 찼는지 확인
+        if (group.isFull()) {
+            throw new GroupException(GroupErrorCode.GROUP_FULL);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.MEMBER_NOT_FOUND));
+
+        // 그룹 멤버 추가
+        GroupMember groupMember = GroupMember.builder()
+                .group(group)
+                .member(member)
+                .role(GroupMember.GroupRole.MEMBER)
+                .build();
+
+        groupMemberRepository.save(groupMember);
+
+        group.incrementMemberCount();
+    }
+
+    // 초대 링크 삭제(soft delete)
+    @Transactional
+    public void deleteInviteToken(Long groupId, Long inviteId, Long memberId) {
+        if (!groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
+            throw new GroupException(GroupErrorCode.NOT_GROUP_MEMBER);
+        }
+
+        GroupInviteToken token = inviteTokenRepository.findById(inviteId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVITE_NOT_FOUND));
+
+        // 해당 그룹의 토큰인지 확인
+        if (!token.getGroup().getId().equals(groupId)) {
+            throw new GroupException(GroupErrorCode.INVALID_INVITE);
+        }
+
+        if (!token.getCreatedBy().getId().equals(memberId)) {
+            throw new GroupException(GroupErrorCode.NOT_INVITE_CREATOR);
+        }
+
+        token.softDelete();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/service/GroupInviteService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupInviteService.java
@@ -45,7 +45,7 @@ public class GroupInviteService {
         // 초대 토큰 생성 (UUID로 생성, 우선 만료일 7일로 설정함)
         GroupInviteToken inviteToken = GroupInviteToken.builder()
                 .group(group)
-                .createdBy(groupMember.getMember())
+                .inviter(groupMember.getMember())
                 .build();
 
         inviteTokenRepository.save(inviteToken);
@@ -133,7 +133,7 @@ public class GroupInviteService {
             throw new GroupException(GroupErrorCode.INVALID_INVITE);
         }
 
-        if (!token.getCreatedBy().getId().equals(memberId)) {
+        if (!token.getInviter().getId().equals(memberId)) {
             throw new GroupException(GroupErrorCode.NOT_INVITE_CREATOR);
         }
 

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -228,6 +228,7 @@ public class GroupService {
     }
 
     // 그룹 삭제 메서드
+    @Transactional
     public void deleteGroup(Long groupId, Long memberId) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
@@ -237,7 +238,7 @@ public class GroupService {
             throw new GroupException(GroupErrorCode.NOT_GROUP_ADMIN);
         }
 
-        groupRepository.delete(group);
+        group.softDelete();
     }
 
     // 그룹 탈퇴 메서드
@@ -285,6 +286,38 @@ public class GroupService {
         group.updateAdmin(newAdminMember);
 
         groupMemberRepository.delete(currentMember);
+
+        // 그룹 멤버 수 감소
+        group.decrementMemberCount();
+    }
+
+    // 그룹 멤버 추방 메서드
+    @Transactional
+    public void expelMember(Long groupId, Long adminId, Long expellerId){
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        GroupMember adminMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, adminId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.NOT_GROUP_MEMBER));
+
+        if (adminMember.getRole() != ADMIN) {
+            throw new GroupException(GroupErrorCode.NOT_GROUP_ADMIN);
+        }
+
+        GroupMember expelMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, expellerId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.NOT_GROUP_MEMBER));
+
+        // 자기 자신 추방 방지
+        if (adminId.equals(expellerId)) {
+            throw new GroupException(GroupErrorCode.CANNOT_EXPEL_SELF);
+        }
+
+        // 이미 삭제된 멤버인지 확인
+        if (expelMember.getIsDeleted()) {
+            throw new GroupException(GroupErrorCode.ALREADY_EXPELLED_MEMBER);
+        }
+
+        expelMember.softDelete();
 
         // 그룹 멤버 수 감소
         group.decrementMemberCount();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,8 @@ spring:
         format_sql: true
 
 app:
+  base-url: ${BASE_URL:http://localhost:8080}
+
   jwt:
     secret: ${JWT_SECRET}
     issuer: muaring


### PR DESCRIPTION
## 📌 관련 이슈
관련있는 이슈 번호(#000)을 적어주세요.
#19 

## ✨ 작업 내용
- GroupInviteToken 엔티티에 expiresAt 컬럼 추가
- 초대 링크 생성 API 추가
- 활성화된 초대 링크 목록 조회 API 추가
- 초대 링크 삭제 API 추가
- 초대 링크 미리보기 API 추가
- 초대 링크로 그룹 가입 API 추가
- 그룹 추방 API, 그룹 삭제 soft delete API 추가
- GroupInviteToken 엔티티의 createdBy 컬럼명을 inviter로 수정
- 사용자 인증 정보를 SecurityUtil을 이용해서 꺼내오는 방식으로 수정

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 전에 추가했던 그룹 추방 API, 그룹 삭제 soft delete API가 머지되었다가 revert하는 과정에서 올라가지 않아서 다시 코드 수정해서 pr 올립니다!