### PR TITLE
feat: 프로필 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
+++ b/src/main/java/com/example/muaring/domain/file/controller/ImageController.java
@@ -1,8 +1,8 @@
 package com.example.muaring.domain.file.controller;
 
 import com.example.muaring.common.response.ApiResponse;
-import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
-import com.example.muaring.domain.file.dto.PresignedUrlResponseDTO;
+import com.example.muaring.domain.file.dto.request.ImageUploadRequestDTO;
+import com.example.muaring.domain.file.dto.response.PresignedUrlResponseDTO;
 import com.example.muaring.domain.file.service.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;

--- a/src/main/java/com/example/muaring/domain/file/dto/request/ImageCreateRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/request/ImageCreateRequestDTO.java
@@ -1,0 +1,38 @@
+package com.example.muaring.domain.file.dto.request;
+
+import com.example.muaring.domain.file.entity.ImageType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public record ImageCreateRequestDTO(
+        @NotBlank(message = "파일 이름은 필수입니다.")
+        String fileName,
+
+        @NotBlank(message = "파일 타입은 필수입니다.")
+        @Pattern(regexp = "^image/(jpeg|jpg|png)$", message = "지원하지 않는 이미지 형식입니다.")
+        String fileType,  // 확장자 관련
+
+        @NotNull(message = "이미지 유형은 필수입니다.")
+        ImageType imageType,  // MEMBER, GROUP
+
+        @NotNull(message = "파일 크기는 필수입니다.")
+        @Positive(message = "파일 크기는 양수여야 합니다.")
+        Long fileSize,
+
+        @NotBlank(message = "s3 key는 필수입니다.")
+        String s3Key
+
+) {
+    @JsonIgnore
+    @Schema(hidden = true)
+    public boolean isCompleteImage() {
+        return fileName != null &&
+                fileType != null &&
+                imageType != null &&
+                fileSize != null;
+    }
+}

--- a/src/main/java/com/example/muaring/domain/file/dto/request/ImageUploadRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/request/ImageUploadRequestDTO.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.file.dto;
+package com.example.muaring.domain.file.dto.request;
 
 import com.example.muaring.domain.file.entity.ImageType;
 import com.example.muaring.domain.file.exception.FileErrorCode;

--- a/src/main/java/com/example/muaring/domain/file/dto/request/ImageUploadRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/request/ImageUploadRequestDTO.java
@@ -1,9 +1,6 @@
 package com.example.muaring.domain.file.dto.request;
 
 import com.example.muaring.domain.file.entity.ImageType;
-import com.example.muaring.domain.file.exception.FileErrorCode;
-import com.example.muaring.domain.file.exception.FileException;
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.*;
 
 public record ImageUploadRequestDTO(
@@ -21,15 +18,18 @@ public record ImageUploadRequestDTO(
         @Positive(message = "파일 크기는 양수여야 합니다.")
         Long fileSize,
 
-        @Nullable  // GROUP 이미지 수정시에만 필요
+        // GROUP 이미지 수정시에만 필요
         Long targetId
 ) {
-        public ImageUploadRequestDTO {
-                if (imageType == ImageType.GROUP && targetId == null) {
-                        throw new FileException(FileErrorCode.TARGET_ID_REQUIRED_FOR_GROUP);
-                }
-                if (imageType == ImageType.MEMBER && targetId != null) {
-                        throw new FileException(FileErrorCode.TARGET_ID_NOT_ALLOWED_FOR_MEMBER);
-                }
+        @AssertTrue(message = "GROUP 이미지 업로드시 targetId는 필수입니다.")
+        public boolean isGroupTargetIdValid() {
+                return imageType != ImageType.GROUP || targetId != null;
         }
+
+        @AssertTrue(message = "MEMBER 이미지 업로드에는 targetId가 사용될 수 없습니다.")
+        public boolean isMemberTargetIdValid() {
+                return imageType != ImageType.MEMBER || targetId == null;
+        }
+
+
 }

--- a/src/main/java/com/example/muaring/domain/file/dto/response/ImageResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/response/ImageResponseDTO.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.file.dto;
+package com.example.muaring.domain.file.dto.response;
 
 import com.example.muaring.domain.file.entity.Image;
 import com.example.muaring.domain.file.entity.ImageType;

--- a/src/main/java/com/example/muaring/domain/file/dto/response/PresignedUrlResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/file/dto/response/PresignedUrlResponseDTO.java
@@ -1,4 +1,4 @@
-package com.example.muaring.domain.file.dto;
+package com.example.muaring.domain.file.dto.response;
 
 public record PresignedUrlResponseDTO(
         String presignedUrl,

--- a/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileErrorCode.java
@@ -17,12 +17,13 @@ public enum FileErrorCode implements ErrorCode {
     TARGET_ID_REQUIRED_FOR_GROUP(3005, HttpStatus.BAD_REQUEST, "그룹 이미지 업로드 시 targetId는 필수입니다."),
     TARGET_ID_NOT_ALLOWED_FOR_MEMBER(3006, HttpStatus.BAD_REQUEST, "개인 프로필 이미지 업로드 시 targetId는 지정할 수 없습니다."),
     MISSING_GROUP_ID(3007, HttpStatus.BAD_REQUEST, "그룹 아이디가 존재하지 누락되었습니다."),
+    INVALID_IMAGE_REQUEST(3008, HttpStatus.BAD_REQUEST, "잘못된 이미지 요청입니다.(필드값 누락)"),
 
     // 403
-    FORBIDDEN_GROUP_IMAGE_UPLOAD(3008, HttpStatus.FORBIDDEN, "그룹 관리자만 그룹 이미지를 업로드할 수 있습니다."),
+    FORBIDDEN_GROUP_IMAGE_UPLOAD(3009, HttpStatus.FORBIDDEN, "그룹 관리자만 그룹 이미지를 업로드할 수 있습니다."),
 
     // 404
-    IMAGE_NOT_FOUND(3009, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
+    IMAGE_NOT_FOUND(3010, HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/file/exception/FileException.java
+++ b/src/main/java/com/example/muaring/domain/file/exception/FileException.java
@@ -4,7 +4,7 @@ import com.example.muaring.common.exception.GeneralException;
 import com.example.muaring.common.response.ErrorCode;
 
 public class FileException extends GeneralException {
-    public FileException(ErrorCode errorCode) {
+    public FileException(FileErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -2,8 +2,8 @@ package com.example.muaring.domain.file.service;
 
 import com.example.muaring.common.security.SecurityUtil;
 import com.example.muaring.config.S3Properties;
-import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
-import com.example.muaring.domain.file.dto.PresignedUrlResponseDTO;
+import com.example.muaring.domain.file.dto.request.ImageUploadRequestDTO;
+import com.example.muaring.domain.file.dto.response.PresignedUrlResponseDTO;
 import com.example.muaring.domain.file.entity.Image;
 import com.example.muaring.domain.file.exception.FileErrorCode;
 import com.example.muaring.domain.file.exception.FileException;

--- a/src/main/java/com/example/muaring/domain/file/validator/FileValidator.java
+++ b/src/main/java/com/example/muaring/domain/file/validator/FileValidator.java
@@ -1,7 +1,7 @@
 package com.example.muaring.domain.file.validator;
 
 import com.example.muaring.config.FilePolicyProperties;
-import com.example.muaring.domain.file.dto.ImageUploadRequestDTO;
+import com.example.muaring.domain.file.dto.request.ImageUploadRequestDTO;
 import com.example.muaring.domain.file.exception.FileErrorCode;
 import com.example.muaring.domain.file.exception.FileException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/muaring/domain/member/controller/MeController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MeController.java
@@ -4,22 +4,27 @@ import com.example.muaring.common.response.ApiResponse;
 import com.example.muaring.common.security.SecurityUtil;
 import com.example.muaring.domain.auth.exception.AuthErrorCode;
 import com.example.muaring.domain.group.dto.MyGroupListResponseDto;
-import com.example.muaring.domain.group.exception.GroupErrorCode;
 import com.example.muaring.domain.group.service.GroupService;
+import com.example.muaring.domain.member.dto.request.MemberProfileUpdateRequestDTO;
+import com.example.muaring.domain.member.dto.response.MemberProfileUpdateResponseDTO;
+import com.example.muaring.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "회원 본인 정보 API", description = "회원 본인 정보 관련 API입니다.")
 @RestController
 @RequestMapping("/me")
 @RequiredArgsConstructor
 public class MeController {
 
+    private final MemberService memberService;
     private final GroupService groupService;
 
+    @Operation(summary = "내 그룹 조회", description = "내가 참여한 그룹 조회 로직입니다.")
     @GetMapping("/groups")
     public ResponseEntity<ApiResponse<MyGroupListResponseDto>> getMyGroups() {
         Long memberId = SecurityUtil.getMemberId();
@@ -30,5 +35,14 @@ public class MeController {
 
         ApiResponse<MyGroupListResponseDto> body = ApiResponse.ok(groupService.getMyGroups(memberId));
         return ResponseEntity.ok(body);
+    }
+
+    @Operation(summary = "내 프로필 수정", description = "내 프로필 수정 로직입니다.")
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<MemberProfileUpdateResponseDTO>> updateProfile(
+            @Valid @RequestBody MemberProfileUpdateRequestDTO requestDTO
+    ) {
+        MemberProfileUpdateResponseDTO responseDTO = memberService.updateProfile(requestDTO);
+        return ResponseEntity.ok(ApiResponse.ok(responseDTO, "프로필이 수정되었습니다."));
     }
 }

--- a/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
     }
 
     // 프로필 등록 (최초)
-    @PostMapping("/profile")
+    @PostMapping
     public ResponseEntity<ApiResponse<MemberProfileResponseDTO>> updateProfile(
             @Valid @RequestBody MemberProfileCreateRequestDTO requestDTO
     ) {

--- a/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/muaring/domain/member/controller/MemberController.java
@@ -2,13 +2,12 @@ package com.example.muaring.domain.member.controller;
 
 import com.example.muaring.common.response.ApiResponse;
 import com.example.muaring.domain.member.dto.request.MemberProfileCreateRequestDTO;
-import com.example.muaring.domain.member.dto.response.MemberProfileResponseDTO;
+import com.example.muaring.domain.member.dto.response.MemberProfileCreateResponseDTO;
 import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
 import com.example.muaring.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -34,10 +33,10 @@ public class MemberController {
 
     // 프로필 등록 (최초)
     @PostMapping
-    public ResponseEntity<ApiResponse<MemberProfileResponseDTO>> updateProfile(
+    public ResponseEntity<ApiResponse<MemberProfileCreateResponseDTO>> updateProfile(
             @Valid @RequestBody MemberProfileCreateRequestDTO requestDTO
     ) {
-        MemberProfileResponseDTO responseDTO = memberService.registerProfile(requestDTO);
+        MemberProfileCreateResponseDTO responseDTO = memberService.registerProfile(requestDTO);
         return ResponseEntity.ok(
                 ApiResponse.ok(responseDTO, "프로필이 생성되었습니다."));
     }

--- a/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileUpdateRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileUpdateRequestDTO.java
@@ -1,0 +1,32 @@
+package com.example.muaring.domain.member.dto.request;
+
+import com.example.muaring.domain.file.dto.request.ImageCreateRequestDTO;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+public record MemberProfileUpdateRequestDTO(
+        @Size(min = 1, max = 10, message = "닉네임은 1자 이상, 10자 이하여야 합니다.")
+        String nickname,
+        @Valid
+        ImageCreateRequestDTO imageRequestDTO,
+        Boolean isPublic,
+        Boolean isDiscoveryEnabled
+) {
+    // ⚪ 모든 필드가 null인지 검사하는 메서드
+    @JsonIgnore
+    @Schema(hidden = true)
+    public boolean isAllFieldNull() {
+        return nickname == null
+                && imageRequestDTO == null
+                && isPublic == null
+                && isDiscoveryEnabled == null;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public boolean isValidImageRequest() {
+        return imageRequestDTO == null || imageRequestDTO.isCompleteImage();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/dto/response/MemberProfileCreateResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/response/MemberProfileCreateResponseDTO.java
@@ -1,15 +1,15 @@
 package com.example.muaring.domain.member.dto.response;
 
-import com.example.muaring.domain.file.dto.ImageResponseDTO;
+import com.example.muaring.domain.file.dto.response.ImageResponseDTO;
 import com.example.muaring.domain.member.entity.Member;
 
-public record MemberProfileResponseDTO(
+public record MemberProfileCreateResponseDTO(
         Long memberId,
         String nickname,
         ImageResponseDTO image
 ) {
-    public static MemberProfileResponseDTO of(Member member, String bucketUrl) {
-        return new  MemberProfileResponseDTO(
+    public static MemberProfileCreateResponseDTO of(Member member, String bucketUrl) {
+        return new MemberProfileCreateResponseDTO(
                 member.getId(),
                 member.getNickname(),
                 ImageResponseDTO.of(member.getProfileImage(), bucketUrl)

--- a/src/main/java/com/example/muaring/domain/member/dto/response/MemberProfileUpdateResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/response/MemberProfileUpdateResponseDTO.java
@@ -1,0 +1,24 @@
+package com.example.muaring.domain.member.dto.response;
+
+import com.example.muaring.domain.file.dto.response.ImageResponseDTO;
+import com.example.muaring.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberProfileUpdateResponseDTO(
+        Long memberId,
+        String nickname,
+        ImageResponseDTO image,
+        Boolean isPublic,
+        Boolean isDiscoveryEnabled
+) {
+    public static MemberProfileUpdateResponseDTO from(Member member, String bucketUrl) {
+        return MemberProfileUpdateResponseDTO.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .image(ImageResponseDTO.of(member.getProfileImage(), bucketUrl))
+                .isPublic(member.getIsPublic())
+                .isDiscoveryEnabled(member.getDiscoveryEnabled())
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/member/entity/Member.java
+++ b/src/main/java/com/example/muaring/domain/member/entity/Member.java
@@ -57,7 +57,7 @@ public class Member extends BaseEntity {
         return member;
     }
 
-    public void updateProfile(String nickname, Image image) {
+    public void createProfile(String nickname, Image image) {
         if (nickname == null || nickname.trim().isEmpty()) {
             throw new IllegalArgumentException("닉네임은 필수입니다.");
         }
@@ -66,5 +66,21 @@ public class Member extends BaseEntity {
         }
         this.nickname = nickname;
         this.profileImage = image;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImage(Image image) {
+        this.profileImage = image;
+    }
+
+    public void updateIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+
+    public void updateDiscoveryEnabled(Boolean discoveryEnabled) {
+        this.discoveryEnabled = discoveryEnabled;
     }
 }

--- a/src/main/java/com/example/muaring/domain/member/response/MemberErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/member/response/MemberErrorCode.java
@@ -11,13 +11,16 @@ public enum MemberErrorCode implements ErrorCode {
 
     // 400 에러
     ALREADY_HAS_PROFILE(2001, HttpStatus.BAD_REQUEST, "이미 프로필 정보가 존재하는 회원입니다."),
+    EMPTY_PROFILE_UPDATE_REQUEST(2002, HttpStatus.BAD_REQUEST, "변경할 프로필 정보가 없습니다."),
 
     // 404 에러
-    MEMBER_NOT_FOUND(2002, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    METRICS_NOT_FOUND(2003, HttpStatus.NOT_FOUND, "핵심 필드를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(2003, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    METRICS_NOT_FOUND(2004, HttpStatus.NOT_FOUND, "핵심 필드를 찾을 수 없습니다."),
 
     // 409 에러
-    METRICS_CONFLICT(2004, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다.");
+    METRICS_CONFLICT(2005, HttpStatus.CONFLICT, "핵심 필드가 존재할 수 없습니다."),
+    DUPLICATE_NICKNAME(2006, HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다.")
+    ;
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -9,8 +9,9 @@ import com.example.muaring.domain.file.exception.FileException;
 import com.example.muaring.domain.file.repository.ImageRepository;
 import com.example.muaring.domain.file.service.ImageService;
 import com.example.muaring.domain.member.dto.request.MemberProfileCreateRequestDTO;
-import com.example.muaring.domain.member.dto.response.MemberProfileResponseDTO;
+import com.example.muaring.domain.member.dto.request.MemberProfileUpdateRequestDTO;
 import com.example.muaring.domain.member.dto.response.MemberProfileCreateResponseDTO;
+import com.example.muaring.domain.member.dto.response.MemberProfileUpdateResponseDTO;
 import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
 import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.file.entity.Image;
@@ -87,5 +88,58 @@ public class MemberService {
                 fileSize
         );
         return imageRepository.save(image);
+    }
+
+    @Transactional
+    public MemberProfileUpdateResponseDTO updateProfile(MemberProfileUpdateRequestDTO requestDTO) {
+        String s3Key = null;
+        try {
+            Long memberId = SecurityUtil.getMemberId();
+            Member member = memberRepository.findById(memberId).
+                    orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            if (requestDTO.isAllFieldNull()) {
+                throw new MemberException(MemberErrorCode.EMPTY_PROFILE_UPDATE_REQUEST);
+            }
+
+            if (requestDTO.nickname() != null) {
+                if (memberRepository.existsByNicknameAndIsDeletedFalse(requestDTO.nickname())) {
+                    throw new MemberException(MemberErrorCode.DUPLICATE_NICKNAME);
+                }
+                member.updateNickname(requestDTO.nickname());
+            }
+
+            if (requestDTO.imageRequestDTO() != null) {
+                s3Key = requestDTO.imageRequestDTO().s3Key();
+                if (!requestDTO.isValidImageRequest()) {
+                    throw new FileException(FileErrorCode.INVALID_IMAGE_REQUEST);
+                }
+
+                Image image = createImage(
+                        requestDTO.imageRequestDTO().fileName(),
+                        requestDTO.imageRequestDTO().fileType(),
+                        requestDTO.imageRequestDTO().imageType(),
+                        requestDTO.imageRequestDTO().s3Key(),
+                        requestDTO.imageRequestDTO().fileSize()
+                );
+                member.updateProfileImage(image);
+            }
+
+            if (requestDTO.isPublic() != null) {
+                member.updateIsPublic(requestDTO.isPublic());
+            }
+
+            if (requestDTO.isDiscoveryEnabled() != null) {
+                member.updateDiscoveryEnabled(requestDTO.isDiscoveryEnabled());
+            }
+
+            return MemberProfileUpdateResponseDTO.from(member, s3Properties.s3().bucketUrl(s3Properties.region()));
+        } catch (Exception e) {
+            if (s3Key != null && !s3Key.isBlank()) {
+                log.warn("❌ 프로필 정보 수정 도중 문제가 발생했습니다.");
+                imageService.deleteObject(s3Key);
+            }
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.example.muaring.domain.file.repository.ImageRepository;
 import com.example.muaring.domain.file.service.ImageService;
 import com.example.muaring.domain.member.dto.request.MemberProfileCreateRequestDTO;
 import com.example.muaring.domain.member.dto.response.MemberProfileResponseDTO;
+import com.example.muaring.domain.member.dto.response.MemberProfileCreateResponseDTO;
 import com.example.muaring.domain.member.dto.response.NicknameCheckResponseDTO;
 import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.file.entity.Image;
@@ -39,7 +40,7 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberProfileResponseDTO registerProfile(MemberProfileCreateRequestDTO requestDTO) {
+    public MemberProfileCreateResponseDTO registerProfile(MemberProfileCreateRequestDTO requestDTO) {
         String s3Key = requestDTO.s3Key();
 
         try {
@@ -51,10 +52,15 @@ public class MemberService {
                 throw new MemberException(MemberErrorCode.ALREADY_HAS_PROFILE);
             }
 
-            Image image = createImage(requestDTO);
+            Image image = createImage(
+                    requestDTO.fileName(),
+                    requestDTO.fileType(),
+                    requestDTO.imageType(),
+                    requestDTO.s3Key(),
+                    requestDTO.fileSize());
 
-            member.updateProfile(requestDTO.nickname(), image);
-            return MemberProfileResponseDTO.of(member, s3Properties.s3().bucketUrl(s3Properties.region()));
+            member.createProfile(requestDTO.nickname(), image);
+            return MemberProfileCreateResponseDTO.of(member, s3Properties.s3().bucketUrl(s3Properties.region()));
         } catch (Exception e) {
             if (s3Key != null && !s3Key.isBlank()) {
                 log.warn("❌ 프로필 정보 생성 도중 문제가 발생했습니다.");
@@ -64,9 +70,9 @@ public class MemberService {
         }
     }
 
-    private Image createImage(MemberProfileCreateRequestDTO requestDTO) {
+    private Image createImage(String fileName, String fileType, ImageType imageType, String s3Key, Long fileSize) {
         // 이미지를 선택하지 않은 경우 기본 이미지 반환
-        if (requestDTO.s3Key() == null || requestDTO.s3Key().isEmpty()) {
+        if (s3Key == null || s3Key.isEmpty()) {
             ImageProperties.DefaultImageProperties defaultProfileImage = imageProperties.defaultProfile();
             return imageRepository.findByImageTypeAndS3Key(ImageType.MEMBER, defaultProfileImage.s3Key())
                     .orElseThrow(() -> new FileException(FileErrorCode.IMAGE_NOT_FOUND));
@@ -74,11 +80,11 @@ public class MemberService {
 
         // 이미지를 선택한 경우 presigned 업로드 이미지 메타데이터 생성
         Image image = Image.create(
-                requestDTO.fileName(),
-                requestDTO.fileType(),
-                ImageType.MEMBER,
-                requestDTO.s3Key(),
-                requestDTO.fileSize()
+                fileName,
+                fileType,
+                imageType,
+                s3Key,
+                fileSize
         );
         return imageRepository.save(image);
     }

--- a/src/main/java/com/example/muaring/domain/social/entity/MusicPost.java
+++ b/src/main/java/com/example/muaring/domain/social/entity/MusicPost.java
@@ -38,9 +38,11 @@ public class MusicPost extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @Builder.Default
     @Column(name = "like_count", nullable = false)
     private Integer likeCount = 0;
 
+    @Builder.Default
     @Column(name = "comment_count", nullable = false)
     private Integer commentCount = 0;
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #53

## ✨ 작업 내용
- 프로필 등록 엔드포인트를 변경했습니다. 
- 빌더 사용을 하더라도 default 값이 들어가도록 @Builder.Default을 설정해주었습니다.
- DTO가 늘어남에 따라 dto 디렉토리 내에서 request, response 디렉토리를 분리했습니다.
- DTO명 중복이 예상되어 DTO명을 더 명시적으로 변경하였습니다.
- DTO가 도메인 예외를 던져 비즈니스 로직에 관여하여 단일 책임 원칙을 위반하고 있어 리팩토링하였습니다.
- 프로필 수정 API를 구현했습니다.

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
참고, 논의할 사항이 있다면 적어주세요