### PR TITLE
refactor: 카카오 로그인 SDK 사용에 따른 로그인 로직 리팩토링

### DIFF
--- a/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/muaring/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.muaring.domain.auth.controller;
 
 import com.example.muaring.common.response.ApiResponse;
+import com.example.muaring.domain.auth.dto.request.KakaoLoginRequest;
 import com.example.muaring.domain.auth.dto.response.LoginResponseDTO;
 import com.example.muaring.domain.auth.entity.AuthProvider;
 import com.example.muaring.domain.auth.service.AuthService;
@@ -12,32 +13,55 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/auth/login")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
 
-    // ⚪ 카카오 서버로부터 리다이렉트 되는 엔드포인트 (테스트용)
-    @GetMapping("/login/{provider}")
-    @Operation(summary = "소셜로그인 인가 코드 수신", description = "소셜 서버로부터 요청되는 인가 코드 수신 로직입니다.")
-    public ResponseEntity<ApiResponse<String>> kakaoLoginRedirect(
-            @PathVariable("provider") String provider,
-            @RequestParam("code") String code
+    // ⚪ 카카오 로그인 (SDK)
+    @PostMapping("/kakao")
+    @Operation(summary = "카카오 소셜로그인 인가 코드 수신", description = "소셜 서버로부터 요청되는 인가 코드 수신 로직입니다.")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> loginWithKakao(
+            @RequestBody KakaoLoginRequest request
     ) {
+        LoginResponseDTO response = authService.kakaoLogin(request);
+        System.out.println("3"+response.accessToken());
+        System.out.println("3"+response.email());
         return ResponseEntity
-                .ok(ApiResponse.ok(provider.toUpperCase() + " 인가 코드가 생성되었습니다."));
+                .ok(ApiResponse.ok(response, "카카오 로그인에 성공했습니다."));
     }
 
-    @Operation(summary = "소셜로그인", description = "소셜 로그인(KAKAO, SPOTIFY) 로직입니다.")
-    @PostMapping("/login/{provider}")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
-            @PathVariable("provider") String provider,
+//    @Operation(summary = "카카오 소셜로그인", description = "카카오 소셜 로그인 로직입니다.")
+//    @PostMapping
+//    public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
+//            @RequestParam("code") String code
+//    ) {
+//        log.info("{} 로그인 요청 수신", provider.toUpperCase());
+//        LoginResponseDTO response = authService.login(code, AuthProvider.valueOf(provider));
+//        return ResponseEntity
+//                .ok(ApiResponse.ok(response, provider + " 로그인에 성공했습니다."));
+//    }
+
+//    // ⚪ 카카오 서버로부터 리다이렉트 되는 엔드포인트 (테스트용)
+//    @GetMapping("/login/{provider}")
+//    @Operation(summary = "소셜로그인 인가 코드 수신", description = "소셜 서버로부터 요청되는 인가 코드 수신 로직입니다.")
+//    public ResponseEntity<ApiResponse<String>> kakaoLoginRedirect(
+//            @PathVariable("provider") String provider,
+//            @RequestParam("code") String code
+//    ) {
+//        return ResponseEntity
+//                .ok(ApiResponse.ok(provider.toUpperCase() + " 인가 코드가 생성되었습니다."));
+//    }
+
+    @Operation(summary = "스포티파이 소셜로그인", description = "소셜 로그인(KAKAO, SPOTIFY) 로직입니다.")
+    @PostMapping("/spotify")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> spotifyLogin(
             @RequestParam("code") String code
     ) {
-        log.info("{} 로그인 요청 수신", provider.toUpperCase());
-        LoginResponseDTO response = authService.login(code, AuthProvider.valueOf(provider));
+        log.info("로그인 요청 수신");
+        LoginResponseDTO response = authService.login(code, AuthProvider.valueOf("SPOTIFY"));
         return ResponseEntity
-                .ok(ApiResponse.ok(response, provider + " 로그인에 성공했습니다."));
+                .ok(ApiResponse.ok(response, "스포티파이 로그인에 성공했습니다."));
     }
 }

--- a/src/main/java/com/example/muaring/domain/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,6 @@
+package com.example.muaring.domain.auth.dto.request;
+
+public record KakaoLoginRequest(
+        String kakaoAccessToken
+) {
+}

--- a/src/main/java/com/example/muaring/domain/auth/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/LoginResponseDTO.java
@@ -1,5 +1,7 @@
 package com.example.muaring.domain.auth.dto.response;
 
+import com.example.muaring.domain.member.entity.Member;
+
 // ✨소셜에서 받은 정보를 이용해 우리 DB에서 사용자를 찾고 우리 서비스용 JWT를 발급한 뒤 클라이언트에 응답하는 DTO (우리 서버 -> 클라이언트(안드로이드 앱))
 public record LoginResponseDTO(
         String accessToken,
@@ -7,4 +9,14 @@ public record LoginResponseDTO(
         Long memberId,
         String email,
         boolean hasNickname
-) { }
+) {
+    public static LoginResponseDTO of(Member member, String accessToken, String refreshToken, Boolean hasNickname) {
+        return new LoginResponseDTO(
+                accessToken,
+                refreshToken,
+                member.getId(),
+                member.getEmail(),
+                hasNickname
+        );
+    }
+}

--- a/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.example.muaring.domain.auth.service;
 
 import com.example.muaring.domain.auth.client.OAuthProviderClient;
+import com.example.muaring.domain.auth.dto.request.KakaoLoginRequest;
 import com.example.muaring.domain.auth.dto.response.*;
 import com.example.muaring.domain.auth.entity.AuthProvider;
 import com.example.muaring.domain.auth.exception.AuthErrorCode;
@@ -51,6 +52,22 @@ public class AuthService {
         return new LoginResponseDTO(accessToken, refreshToken, account.getMember().getId(), account.getMember().getEmail(), hasNickname);
     }
 
+    @Transactional
+    public LoginResponseDTO kakaoLogin(KakaoLoginRequest request) {
+        OAuthProviderClient client = findClient("KAKAO");
+
+        OAuthMemberInfoResponseDTO memberInfoResponseDTO = client.fetchMemberInfo(request.kakaoAccessToken());
+        System.out.println("1"+memberInfoResponseDTO.email());
+        OAuthAccount account = findOrCreateAccount(memberInfoResponseDTO, "KAKAO");
+        Member member = account.getMember();
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail());
+        System.out.println("2"+accessToken);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getEmail());
+        boolean hasNickname = member.getNickname() != null && !member.getNickname().isEmpty();
+
+        return LoginResponseDTO.of(member, accessToken, refreshToken, hasNickname);
+    }
+
     private OAuthAccount createMemberAndAccount(OAuthMemberInfoResponseDTO memberInfoResponseDTO, AuthProvider authProvider) {
         Member member = memberRepository.findByEmail(memberInfoResponseDTO.email())
                 .orElseGet(() -> memberRepository.save(Member.CreateOAuthMember(memberInfoResponseDTO.email())
@@ -58,5 +75,23 @@ public class AuthService {
 
         // oAuthAccount 정보 생성
         return oauthAccountRepository.save(OAuthAccount.createOAuthAccount(authProvider, memberInfoResponseDTO.providerId(), member));
+    }
+
+    // ⚪ provider에 맞는 구현체를 찾아주는 메서드
+    private OAuthProviderClient findClient(String provider) {
+        AuthProvider authProvider = AuthProvider.valueOf(provider.toUpperCase());
+        return providerClients.stream()
+                .filter(c -> c.getAuthProvider() == authProvider)
+                .findFirst()
+                .orElseThrow(() -> new AuthException(AuthErrorCode.PROVIDER_NOT_SUPPORTED));
+    }
+
+    // ⚪ 가입된 계정이 없으면 계정을 생성하는 메서드
+    private OAuthAccount findOrCreateAccount(OAuthMemberInfoResponseDTO memberInfoResponseDTO,
+                                             String provider) {
+        AuthProvider authProvider = AuthProvider.valueOf(provider.toUpperCase());
+        return oauthAccountRepository
+                .findByAuthProviderAndAuthProviderId(authProvider, memberInfoResponseDTO.providerId())
+                .orElseGet(() -> createMemberAndAccount(memberInfoResponseDTO, authProvider));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #61 

## ✨ 작업 내용
- 카카오 로그인 SDK 사용에 따른 로그인 로직 리팩토링

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
원래는 스포티파이, 카카오 로그인 통합 api 였는데, sdk을 이용하면서 queryparm이 달라져 api를 분리하였습니다. 우선 카카오 로그인만 별도 분리했습니다.