### PR TITLE
refactor: 프론트와 통신 과정 중 발생한 문제들에 관한 리팩토링

### DIFF
--- a/src/main/java/com/example/muaring/domain/auth/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/example/muaring/domain/auth/dto/response/LoginResponseDTO.java
@@ -8,14 +8,16 @@ public record LoginResponseDTO(
         String refreshToken,
         Long memberId,
         String email,
+        String nickname,
         boolean hasNickname
 ) {
-    public static LoginResponseDTO of(Member member, String accessToken, String refreshToken, Boolean hasNickname) {
+    public static LoginResponseDTO of(Member member, String accessToken, String refreshToken, String nickname, Boolean hasNickname) {
         return new LoginResponseDTO(
                 accessToken,
                 refreshToken,
                 member.getId(),
                 member.getEmail(),
+                member.getNickname(),
                 hasNickname
         );
     }

--- a/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
@@ -55,7 +55,7 @@ public class AuthService {
         String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getEmail());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getEmail());
         boolean hasNickname = member.getNickname() != null && !member.getNickname().isEmpty();
-        return new LoginResponseDTO(accessToken, refreshToken, account.getMember().getId(), account.getMember().getEmail(), hasNickname);
+        return new LoginResponseDTO(accessToken, refreshToken, account.getMember().getId(), account.getMember().getEmail(), member.getNickname(), hasNickname);
     }
 
     @Transactional
@@ -69,7 +69,7 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getEmail());
         boolean hasNickname = member.getNickname() != null && !member.getNickname().isEmpty();
 
-        return LoginResponseDTO.of(member, accessToken, refreshToken, hasNickname);
+        return LoginResponseDTO.of(member, accessToken, refreshToken, member.getNickname(), hasNickname);
     }
 
     private OAuthAccount createMemberAndAccount(OAuthMemberInfoResponseDTO memberInfoResponseDTO, AuthProvider authProvider) {

--- a/src/main/java/com/example/muaring/domain/file/service/ImageService.java
+++ b/src/main/java/com/example/muaring/domain/file/service/ImageService.java
@@ -76,12 +76,6 @@ public class ImageService {
                 .bucket(s3Properties.s3().bucket())
                 .key(s3Key)
                 .contentType(request.fileType())
-                .contentLength(request.fileSize())
-                .metadata(Map.of(
-                        "original-filename", safeFileName(request.fileName()),
-                        "image-type", request.fileType()
-                ))
-                .serverSideEncryption(ServerSideEncryption.AES256)  // S3에 저장시 데이터 자동 암호화
                 .build();
 
         Duration uploadDuration = Duration.ofMinutes(s3Properties.s3().presign().uploadExpMinutes());
@@ -129,10 +123,11 @@ public class ImageService {
 
     // ⚪ 파일명을 정제하는 메서드
     private String safeFileName(String fileName) {
-        return fileName
+        String cleaned = fileName
                 .replaceAll("[^a-zA-Z0-9._-]", "_")
-                .replaceAll("_+", "_")
-                .substring(0, Math.min(fileName.length(), 100));
+                .replaceAll("_+", "_");
+
+        return cleaned.substring(0, Math.min(cleaned.length(), 100));
     }
 
     // ⚪ 업로드된 s3 파일을 삭제하는 메서드

--- a/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileCreateRequestDTO.java
+++ b/src/main/java/com/example/muaring/domain/member/dto/request/MemberProfileCreateRequestDTO.java
@@ -8,5 +8,5 @@ public record MemberProfileCreateRequestDTO(
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
         String nickname,
-        ImageCreateRequestDTO imageRequestDTO
+        ImageCreateRequestDTO imageRequest
 ) { }

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -57,15 +57,15 @@ public class MemberService {
                 throw new MemberException(MemberErrorCode.ALREADY_HAS_PROFILE);
             }
 
-            Image image = createImageIfExists(requestDTO.imageRequestDTO());
+            Image image = createImageIfExists(requestDTO.imageRequest());
 
             member.createProfile(requestDTO.nickname(), image);
             return MemberProfileCreateResponseDTO.of(member, s3Properties.s3().bucketUrl(s3Properties.region()));
         } catch (Exception e) {
-            if (requestDTO.imageRequestDTO() != null
-                    && requestDTO.imageRequestDTO().isCompleteImage()) {
+            if (requestDTO.imageRequest() != null
+                    && requestDTO.imageRequest().isCompleteImage()) {
                 log.warn("❌ 프로필 정보 생성 도중 문제가 발생했습니다.");
-                imageService.deleteObject(requestDTO.imageRequestDTO().s3Key());
+                imageService.deleteObject(requestDTO.imageRequest().s3Key());
             }
             throw e;
         }


### PR DESCRIPTION
## 📌 관련 이슈
closed #69

## ✨ 작업 내용
- 로그인 시 프론트에서 닉네임 토스트를 띄우기 위해 응답에 닉네임 추가
- 이미지 파일명 정제 url 리팩토링
- presigned url 생성시 불필요한 헤더 삭제
- 프로필 등록 시 이미지 메타데이터 생성안되는 문제 해결 (프론트와 응답 필드값 통일)