### PR TITLE
feat: 그룹 관련 기능 및 api 추가

### DIFF
--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -89,13 +89,14 @@ public class GroupController {
     }
 
 
-    // [GET] /groups/{groupId}/members
-    // 그룹 멤버 목록 조회
+    // [GET] /groups/{groupId}/members?search=닉네임
+    // 그룹 멤버 목록 조회 + 검색
     @GetMapping("/{groupId}/members")
     public ResponseEntity<ApiResponse<List<GroupMemberResponseDto>>> getGroupMembers(
-            @PathVariable Long groupId) {
+            @PathVariable Long groupId,
+            @RequestParam(required = false) String search) {
         Long memberId = SecurityUtil.getMemberId();
-        List<GroupMemberResponseDto> members = groupService.getGroupMembers(groupId, memberId);
+        List<GroupMemberResponseDto> members = groupService.getGroupMembers(groupId, memberId, search);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok(members, "그룹 멤버 목록을 조회했습니다."));

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -9,6 +9,7 @@ import com.example.muaring.domain.group.dto.GroupCreateResponseDto;
 import com.example.muaring.domain.group.dto.GroupListResponseDto;
 import com.example.muaring.domain.group.service.GroupService;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -190,5 +191,19 @@ public class GroupController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok("그룹 멤버 추방을 완료했습니다."));
+    }
+
+     // [GET] /groups/{postId}
+     // 게시물 상세 조회
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시물 상세 조회", description = "게시물의 기본 정보를 조회합니다. 댓글은 별도 API로 조회하세요.")
+    public ResponseEntity<ApiResponse<MusicPostDetailResponseDto>> getPostDetail(
+            @PathVariable Long postId) {
+        Long memberId = SecurityUtil.getMemberId();
+        MusicPostDetailResponseDto response = groupService.getPostDetail(postId, memberId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(response, "게시물을 조회했습니다."));
     }
 }

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupMemberResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupMemberResponseDto.java
@@ -16,6 +16,20 @@ public class GroupMemberResponseDto {
         private String role;
         private String joinedAt;
 
+
+    // 최신 음악 정보 추가
+    private RecentMusicDto recentMusic;
+
+    @Getter
+    @Builder
+    public static class RecentMusicDto {
+        private Long musicId;
+        private String musicName;
+        private String artistName;
+        private String albumImgUrl;
+        private Long postId;
+    }
+
     public static GroupMemberResponseDto from(GroupMember groupMember) {
         return GroupMemberResponseDto.builder()
                 .memberId(groupMember.getMember().getId())
@@ -25,6 +39,7 @@ public class GroupMemberResponseDto {
                         : null)
                 .role(groupMember.getRole().name())
                 .joinedAt(groupMember.getCreatedAt().toString())
+                .recentMusic(null) // 서비스에서 설정할 예정
                 .build();
     }
 }

--- a/src/main/java/com/example/muaring/domain/group/dto/MusicPostDetailResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/MusicPostDetailResponseDto.java
@@ -1,0 +1,91 @@
+package com.example.muaring.domain.group.dto;
+
+import com.example.muaring.domain.social.entity.MusicPost;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MusicPostDetailResponseDto {
+
+    // 게시물 정보
+    private Long postId;
+    private String content;
+    private Integer likeCount;
+    private Integer commentCount;
+    private boolean isLiked; // 현재 사용자가 좋아요를 눌렀는지
+    private LocalDateTime createdAt;
+
+    // 작성자 정보
+    private AuthorDto author;
+
+    // 음악 정보
+    private MusicDto music;
+
+    // 그룹 정보 (있는 경우)
+    private GroupDto group;
+
+    @Getter
+    @Builder
+    public static class AuthorDto {
+        private Long memberId;
+        private String nickname;
+        private String profileImageUrl;
+    }
+
+    @Getter
+    @Builder
+    public static class MusicDto {
+        private Long musicId;
+        private String spotifyId;
+        private String name;
+        private String artistName;
+        private String albumName;
+        private String albumImgUrl;
+        private Integer durationMs;
+        private String previewUrl;
+    }
+
+    @Getter
+    @Builder
+    public static class GroupDto {
+        private Long groupId;
+        private String name;
+        private String imageUrl;
+    }
+
+    public static MusicPostDetailResponseDto of(MusicPost post, boolean isLiked) {
+        return MusicPostDetailResponseDto.builder()
+                .postId(post.getId())
+                .content(post.getContent())
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .isLiked(isLiked)
+                .createdAt(post.getCreatedAt())
+                .author(AuthorDto.builder()
+                        .memberId(post.getMember().getId())
+                        .nickname(post.getMember().getNickname())
+                        .profileImageUrl(post.getMember().getProfileImage() != null
+                                ? post.getMember().getProfileImage().getUrl()
+                                : null)
+                        .build())
+                .music(MusicDto.builder()
+                        .musicId(post.getMusic().getId())
+                        .spotifyId(post.getMusic().getSpotifyId())
+                        .name(post.getMusic().getName())
+                        .artistName(post.getMusic().getArtistName())
+                        .albumName(post.getMusic().getAlbumName())
+                        .albumImgUrl(post.getMusic().getAlbumImgUrl())
+                        .durationMs(post.getMusic().getDurationMs())
+                        .previewUrl(post.getMusic().getPreviewUrl())
+                        .build())
+                .group(post.getGroup() != null ? GroupDto.builder()
+                        .groupId(post.getGroup().getId())
+                        .name(post.getGroup().getName())
+                        .imageUrl(post.getGroup().getImageUrl())
+                        .build() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/example/muaring/domain/group/dto/MusicPostDetailResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/MusicPostDetailResponseDto.java
@@ -84,7 +84,7 @@ public class MusicPostDetailResponseDto {
                 .group(post.getGroup() != null ? GroupDto.builder()
                         .groupId(post.getGroup().getId())
                         .name(post.getGroup().getName())
-                        .imageUrl(post.getGroup().getImageUrl())
+                        .imageUrl(post.getGroup().getGroupImage())
                         .build() : null)
                 .build();
     }

--- a/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
@@ -38,4 +38,15 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     // memberId로 해당 멤버가 가입한 그룹의 ID들만 조회
     @Query("select gm.group.id from GroupMember gm where gm.member.id = :memberId")
     List<Long> findGroupIdsByMemberId(@Param("memberId") Long memberId);
+
+    // 닉네임으로 검색
+    @Query("SELECT gm FROM GroupMember gm " +
+            "JOIN FETCH gm.member m " +
+            "WHERE gm.group.id = :groupId " +
+            "AND m.nickname LIKE %:search% " +
+            "AND gm.isDeleted = false " +
+            "ORDER BY m.nickname ASC")
+    List<GroupMember> findByGroupIdAndMemberNicknameContaining(
+            @Param("groupId") Long groupId,
+            @Param("search") String search);
 }

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -230,7 +230,7 @@ public class GroupService {
     }
 
     // 그룹 멤버 조회 메서드
-    public List<GroupMemberResponseDto> getGroupMembers(Long groupId, Long memberId) {
+    public List<GroupMemberResponseDto> getGroupMembers(Long groupId, Long memberId, String search) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
@@ -242,7 +242,14 @@ public class GroupService {
             }
         }
 
-        List<GroupMember> groupMembers = groupMemberRepository.findByGroupId(groupId);
+        List<GroupMember> groupMembers;
+
+        // 검색어가 있으면 필터링
+        if (search != null && !search.trim().isEmpty()) {
+            groupMembers = groupMemberRepository.findByGroupIdAndMemberNicknameContaining(groupId, search.trim());
+        } else {
+            groupMembers = groupMemberRepository.findByGroupId(groupId);
+        }
 
         return groupMembers.stream()
                 .map(GroupMemberResponseDto::from)

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -251,8 +251,49 @@ public class GroupService {
             groupMembers = groupMemberRepository.findByGroupId(groupId);
         }
 
+        // 모든 멤버 ID 수집
+        List<Long> memberIds = groupMembers.stream()
+                .map(gm -> gm.getMember().getId())
+                .toList();
+
+        // 한 번에 최신 게시물 조회
+        List<MusicPost> latestPosts = musicPostRepository.findLatestPostsByMemberIds(memberIds);
+
+        // memberId를 키로 하는 Map 생성
+        Map<Long, MusicPost> latestPostMap = latestPosts.stream()
+                .collect(Collectors.toMap(
+                        post -> post.getMember().getId(),
+                        post -> post
+                ));
+
         return groupMembers.stream()
-                .map(GroupMemberResponseDto::from)
+                .map(groupMember -> {
+                    GroupMemberResponseDto.GroupMemberResponseDtoBuilder builder =
+                            GroupMemberResponseDto.builder()
+                                    .memberId(groupMember.getMember().getId())
+                                    .nickname(groupMember.getMember().getNickname())
+                                    .profileImageUrl(groupMember.getMember().getProfileImage() != null
+                                            ? groupMember.getMember().getProfileImage().getUrl()
+                                            : null)
+                                    .role(groupMember.getRole().name())
+                                    .joinedAt(groupMember.getCreatedAt().toString());
+
+                    // Map에서 해당 멤버의 최신 게시물 찾기
+                    MusicPost latestPost = latestPostMap.get(groupMember.getMember().getId());
+                    if (latestPost != null) {
+                        GroupMemberResponseDto.RecentMusicDto recentMusic =
+                                GroupMemberResponseDto.RecentMusicDto.builder()
+                                        .musicId(latestPost.getMusic().getId())
+                                        .postId(latestPost.getId())
+                                        .musicName(latestPost.getMusic().getName())
+                                        .artistName(latestPost.getMusic().getArtistName())
+                                        .albumImgUrl(latestPost.getMusic().getAlbumImgUrl())
+                                        .build();
+                        builder.recentMusic(recentMusic);
+                    }
+
+                    return builder.build();
+                })
                 .toList();
     }
 

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -11,8 +11,12 @@ import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.member.exception.MemberException;
 import com.example.muaring.domain.member.repository.MemberRepository;
 import com.example.muaring.domain.member.response.MemberErrorCode;
+import com.example.muaring.domain.music.exception.MusicErrorCode;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
 import com.example.muaring.domain.social.entity.MusicPost;
+import com.example.muaring.domain.social.exception.post.PostErrorCode;
+import com.example.muaring.domain.social.exception.post.PostException;
+import com.example.muaring.domain.social.repository.LikeRepository;
 import com.example.muaring.domain.social.repository.MusicPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -40,6 +44,7 @@ public class GroupService {
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMusicProfileRepository groupMusicProfileRepository;
     private final MusicPostRepository musicPostRepository;
+    private final LikeRepository likeRepository;
     private final GroupPlaylistRepository groupPlaylistRepository;
 
     // 그룹 생성
@@ -447,5 +452,29 @@ public class GroupService {
 
         // 그룹 멤버 수 감소
         group.decrementMemberCount();
+    }
+
+     // 게시물 상세 조회 (댓글 제외. 댓글은 댓글 조회 api로 프론트에서 따로 불러오게 함)
+
+    public MusicPostDetailResponseDto getPostDetail(Long postId, Long memberId) {
+        // 게시물 조회
+        MusicPost post = musicPostRepository.findByIdWithDetails(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        // 그룹 게시물인 경우 접근 권한 확인
+        if (post.getGroup() != null && !post.getGroup().getIsPublic()) {
+            boolean isMember = groupMemberRepository.existsByGroupIdAndMemberId(
+                    post.getGroup().getId(),
+                    memberId
+            );
+            if (!isMember) {
+                throw new GroupException(GroupErrorCode.NOT_GROUP_MEMBER);
+            }
+        }
+
+        // 현재 사용자가 좋아요를 눌렀는지 확인
+        boolean isLiked = likeRepository.existsByPostIdAndMemberId(postId, memberId);
+
+        return MusicPostDetailResponseDto.of(post, isLiked);
     }
 }

--- a/src/main/java/com/example/muaring/domain/social/repository/LikeRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/LikeRepository.java
@@ -11,4 +11,7 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     Optional<Like> findByPostIdAndMemberId(Long postId, Long memberId);
     void deleteByPostIdAndMemberId(Long postId, Long memberId);
+
+    // 특정 게시물에 특정 회원이 좋아요를 눌렀는지 확인
+    boolean existsByPostIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -132,4 +132,13 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
             "ORDER BY p.createdAt DESC")
     List<MusicPost> findLatestPostsByMemberIds(@Param("memberIds") List<Long> memberIds);
 
+    // 게시물 상세 조회 (연관 엔티티 fetch join으로 한 번에 조회)
+    @Query("SELECT p FROM MusicPost p " +
+            "JOIN FETCH p.member m " +
+            "LEFT JOIN FETCH m.profileImage " +
+            "JOIN FETCH p.music " +
+            "LEFT JOIN FETCH p.group g " +
+            "WHERE p.id = :postId")
+    Optional<MusicPost> findByIdWithDetails(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -127,6 +127,7 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
             "WHERE p.id IN (" +
             "  SELECT MAX(p2.id) FROM MusicPost p2 " +
             "  WHERE p2.member.id IN :memberIds " +
+            "  AND p2.isProfile = true " +
             "  GROUP BY p2.member.id" +
             ") " +
             "ORDER BY p.createdAt DESC")

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -119,4 +119,17 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
             @Param("from") LocalDateTime from
     );
 
+    // 특정 멤버의 가장 최신 게시물 조회
+    Optional<MusicPost> findFirstByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    // 여러 멤버의 최신 게시물을 한 번에 조회 (성능 최적화)
+    @Query("SELECT p FROM MusicPost p " +
+            "WHERE p.id IN (" +
+            "  SELECT MAX(p2.id) FROM MusicPost p2 " +
+            "  WHERE p2.member.id IN :memberIds " +
+            "  GROUP BY p2.member.id" +
+            ") " +
+            "ORDER BY p.createdAt DESC")
+    List<MusicPost> findLatestPostsByMemberIds(@Param("memberIds") List<Long> memberIds);
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련있는 이슈 번호(#000)을 적어주세요.
#19

## ✨ 작업 내용
- 그룹 검색 기능 추가
- 그룹 멤버 조회 시 가장 최근에 올린 게시물의 음악이 함께 뜨도록 수정
- 그룹 게시물 상세 조회 api 구현

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 그룹 멤버 조회 시 함께 뜨는 최신 음악 기준이 그룹에 올린 게시물 기준인지, 개인 피드에 올린 게시물 기준인지 구별할 필요가 있다면 코드 수정이 필요합니다.