### PR TITLE
[FEAT] 그룹, 피드 관련 api 추가 및 수정

### DIFF
--- a/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/muaring/domain/auth/service/AuthService.java
@@ -69,6 +69,8 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getEmail());
         boolean hasNickname = member.getNickname() != null && !member.getNickname().isEmpty();
 
+        log.info("accessToken: " + accessToken);
+
         return LoginResponseDTO.of(member, accessToken, refreshToken, member.getNickname(), hasNickname);
     }
 

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -12,6 +12,7 @@ import com.example.muaring.domain.group.service.GroupService;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -119,7 +120,7 @@ public class GroupController {
 
 
     // [GET] /groups/{groupId}/posts
-    // 그룹 피드 조회
+    // 그룹 피드 동적 조회
     @GetMapping("/{groupId}/posts")
     public ResponseEntity<ApiResponse<Page<MusicPostFeedResponseDto>>> getGroupFeed(
             @PathVariable Long groupId,
@@ -139,6 +140,24 @@ public class GroupController {
                 ApiResponse.ok(post, "그룹 피드 조회 성공")
         );
     }
+
+    // [GET] /groups/{groupId}/posts/today
+    // 그룹 오늘의 피드 조회
+    @GetMapping("/{groupId}/posts/today")
+    public ResponseEntity<ApiResponse<Page<MusicPostFeedResponseDto>>> getTodayGroupFeed(
+            @PathVariable Long groupId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<MusicPostFeedResponseDto> posts =
+                groupService.getTodayGroupFeed(groupId, pageable);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(posts, "그룹 오늘의 피드 조회 성공")
+        );
+    }
+
 
     // [DELETE] /groups/{groupId}
     // 그룹 삭제

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -8,6 +8,7 @@ import com.example.muaring.domain.group.dto.GroupCreateRequestDto;
 import com.example.muaring.domain.group.dto.GroupCreateResponseDto;
 import com.example.muaring.domain.group.dto.GroupListResponseDto;
 import com.example.muaring.domain.group.service.GroupService;
+import com.example.muaring.domain.music.dto.MusicHistoryDTO;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -156,6 +157,22 @@ public class GroupController {
         return ResponseEntity.ok(
                 ApiResponse.ok(posts, "그룹 오늘의 피드 조회 성공")
         );
+    }
+
+    // [GET] /groups/{groupId}/history?year=2025&month=10 (params는 안 넣어도 OK)
+    // 그룹 히스토리 조회
+    @GetMapping("/{groupId}/history")
+    public ResponseEntity<ApiResponse<Page<MusicHistoryDTO>>> getMusicHistoryByGroup(
+            @PathVariable Long groupId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month,
+            @PageableDefault(page = 0, size = 20) Pageable pageable
+    ) {
+        Page<MusicHistoryDTO> history = groupService.getMusicHistoryByGroup(groupId, year, month, pageable);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(history, "그룹의 음악 히스토리 조회가 완료되었습니다."));
     }
 
 

--- a/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/muaring/domain/group/controller/GroupController.java
@@ -229,9 +229,9 @@ public class GroupController {
                 .body(ApiResponse.ok("그룹 멤버 추방을 완료했습니다."));
     }
 
-     // [GET] /groups/{postId}
+     // [GET] /groups/posts/{postId}
      // 게시물 상세 조회
-    @GetMapping("/{postId}")
+    @GetMapping("/posts/{postId}")
     @Operation(summary = "게시물 상세 조회", description = "게시물의 기본 정보를 조회합니다. 댓글은 별도 API로 조회하세요.")
     public ResponseEntity<ApiResponse<MusicPostDetailResponseDto>> getPostDetail(
             @PathVariable Long postId) {

--- a/src/main/java/com/example/muaring/domain/group/dto/GroupProfileResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/group/dto/GroupProfileResponseDto.java
@@ -20,11 +20,11 @@ public class GroupProfileResponseDto {
     private Long groupId;
     private String name;
     private String description;
-    private List<Long> groupCategoryIds; // 그룹 카테고리 id 리스트
-    private Integer totalMusicCount;     // 그룹 playlist의 음악 개수
-    private Integer totalPostCount;      // 그룹 내 게시물 개수
+    private List<String> groupCategories;   // 그룹 카테고리 리스트
+    private Integer totalMusicCount;        // 그룹 playlist의 음악 개수
+    private Integer totalPostCount;         // 그룹 내 게시물 개수
     private Integer memberCount;
-    private String imageUrl;             // 프로필 이미지 url
+    private String imageUrl;                // 프로필 이미지 url
     private LocalDateTime createdAt;
 
     /**
@@ -32,7 +32,7 @@ public class GroupProfileResponseDto {
      */
     public static GroupProfileResponseDto of(
             Group group,
-            List<Long> groupCategoryIds,
+            List<String> groupCategoryNames,
             int totalMusicCount,
             int totalPostCount
     ) {
@@ -40,7 +40,7 @@ public class GroupProfileResponseDto {
                 .groupId(group.getId())
                 .name(group.getName())
                 .description(group.getDescription())
-                .groupCategoryIds(groupCategoryIds)
+                .groupCategories(groupCategoryNames)
                 .totalMusicCount(totalMusicCount)
                 .totalPostCount(totalPostCount)
                 .memberCount(group.getMemberCount())
@@ -54,14 +54,14 @@ public class GroupProfileResponseDto {
      */
     public static List<GroupProfileResponseDto> fromEntities(
             List<Group> groups,
-            Map<Long, List<Long>> categoryIdsByGroup,
+            Map<Long, List<String>> categoryNamesByGroup,
             Map<Long, Integer> musicCountByGroup,
             Map<Long, Integer> postCountByGroup
     ) {
         return groups.stream()
                 .map(group -> GroupProfileResponseDto.of(
                         group,
-                        categoryIdsByGroup.getOrDefault(group.getId(), List.of()),
+                        categoryNamesByGroup.getOrDefault(group.getId(), List.of()),
                         musicCountByGroup.getOrDefault(group.getId(), 0),
                         postCountByGroup.getOrDefault(group.getId(), 0)
                 ))

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.Collections;
@@ -226,6 +227,23 @@ public class GroupService {
         }
 
         // DTO 변환
+        return posts.map(MusicPostFeedResponseDto::from);
+    }
+
+    // 그룹 내 오늘의 피드 조회
+    @Transactional
+    public Page<MusicPostFeedResponseDto> getTodayGroupFeed(
+            Long groupId,
+            Pageable pageable
+    ) {
+        LocalDate today = LocalDate.now();
+
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end = today.plusDays(1).atStartOfDay();
+
+        Page<MusicPost> posts = musicPostRepository
+                .findByGroup_IdAndCreatedAtBetween(groupId, start, end, pageable);
+
         return posts.map(MusicPostFeedResponseDto::from);
     }
 

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -12,7 +12,6 @@ import com.example.muaring.domain.member.exception.MemberException;
 import com.example.muaring.domain.member.repository.MemberRepository;
 import com.example.muaring.domain.member.response.MemberErrorCode;
 import com.example.muaring.domain.music.dto.MusicHistoryDTO;
-import com.example.muaring.domain.music.exception.MusicErrorCode;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
 import com.example.muaring.domain.social.entity.MusicPost;
 import com.example.muaring.domain.social.exception.post.PostErrorCode;
@@ -187,17 +186,31 @@ public class GroupService {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
-        List<Long> categoryIds = groupCategoryRepository.findCategoryIdsByGroupId(groupId);
         int totalPostCount = musicPostRepository.countActiveByGroupId(groupId);
         int totalMusicCount = groupPlaylistRepository.countByGroupId(groupId);
 
+        // 1) groupId 하나를 리스트로 감싸서 조회
+        List<GroupIdCategoryNameProjection> mappings =
+                mappingRepository.findPairsWithNamesByGroupIds(List.of(groupId));
+
+        // 2) projection → category displayName 리스트로 변환
+        List<String> categoryNames = mappings.stream()
+                .map(projection -> {
+                    String code = projection.getCategoryCode(); // "k_pop", "indie" ...
+                    return GroupCategoryType.fromName(code)     // enum 매핑
+                            .getDisplayName();                  // "케이팝", "인디" ...
+                })
+                .distinct() // 같은 카테고리 중복 방지
+                .toList();
+
         return GroupProfileResponseDto.of(
                 group,
-                categoryIds,
+                categoryNames,      // 이름 리스트로 전달
                 totalMusicCount,
                 totalPostCount
         );
     }
+
 
     // 그룹 내 피드 조회 메서드
     @Transactional

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -11,6 +11,7 @@ import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.member.exception.MemberException;
 import com.example.muaring.domain.member.repository.MemberRepository;
 import com.example.muaring.domain.member.response.MemberErrorCode;
+import com.example.muaring.domain.music.dto.MusicHistoryDTO;
 import com.example.muaring.domain.music.exception.MusicErrorCode;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
 import com.example.muaring.domain.social.entity.MusicPost;
@@ -26,10 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.example.muaring.domain.group.entity.GroupMember.GroupRole.ADMIN;
@@ -252,7 +250,80 @@ public class GroupService {
         return posts.map(MusicPostFeedResponseDto::from);
     }
 
+    // 그룹 히스토리 조회 메서드
+    @Transactional(readOnly = true)
+    public Page<MusicHistoryDTO> getMusicHistoryByGroup(
+            Long groupId,
+            Integer year,
+            Integer month,
+            Pageable pageable
+    ) {
+        // 1. 그룹 존재 여부 체크 (선택사항이지만 있으면 좋음)
+        if (!groupRepository.existsById(groupId)) {
+            throw new GroupException(GroupErrorCode.GROUP_NOT_FOUND);
+        }
+
+        // 2. year, month 없으면 -> 현재 달 기준
+        YearMonth targetMonth;
+        if (year != null && month != null) {
+            targetMonth = YearMonth.of(year, month);
+        } else {
+            targetMonth = YearMonth.now();
+        }
+
+        LocalDateTime start = targetMonth.atDay(1).atStartOfDay();
+        LocalDateTime end = targetMonth.plusMonths(1).atDay(1).atStartOfDay();
+
+        // 3. 해당 월의 전체 포스트 가져오기 (삭제되지 않은 것만, 시간 오름차순)
+        List<MusicPost> posts = musicPostRepository
+                .findByGroup_IdAndIsDeletedFalseAndCreatedAtBetweenOrderByCreatedAtAsc(
+                        groupId,
+                        start,
+                        end
+                );
+
+        // 4. 하루당 "가장 빠른" 포스트만 선택
+        //    createdAt ASC로 정렬되어 있으니, 날짜별로 첫 번째 것만 선택하면 됨
+        Map<LocalDate, MusicPost> earliestPostPerDay = new LinkedHashMap<>();
+
+        for (MusicPost post : posts) {
+            LocalDate day = post.getCreatedAt().toLocalDate();
+            // 처음 본 날짜일 때만 put (이미 있으면 더 늦게 올라온 거라 무시)
+            earliestPostPerDay.putIfAbsent(day, post);
+        }
+
+        // 5. MusicHistoryDTO 리스트로 변환 (날짜 순 유지)
+        List<MusicHistoryDTO> dailyHistories = earliestPostPerDay.values().stream()
+                .map(post -> MusicHistoryDTO.builder()
+                        .postId(post.getId())
+                        .musicId(post.getMusic().getId())
+                        .title(post.getMusic().getName())
+                        .artist(post.getMusic().getArtistName())
+                        .albumImage(post.getMusic().getAlbumImgUrl())
+                        .createdAt(post.getCreatedAt())
+                        .build()
+                )
+                .toList();
+
+        // 6. Page 처리 (in-memory pagination)
+        int total = dailyHistories.size();
+        int pageSize = pageable.getPageSize();
+        int currentPage = pageable.getPageNumber();
+        int fromIndex = currentPage * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, total);
+
+        List<MusicHistoryDTO> pageContent;
+        if (fromIndex >= total) {
+            pageContent = List.of();
+        } else {
+            pageContent = dailyHistories.subList(fromIndex, toIndex);
+        }
+
+        return new PageImpl<>(pageContent, pageable, total);
+    }
+
     // 그룹 멤버 조회 메서드
+    @Transactional
     public List<GroupMemberResponseDto> getGroupMembers(Long groupId, Long memberId, String search) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));

--- a/src/main/java/com/example/muaring/domain/music/dto/MusicHistoryDTO.java
+++ b/src/main/java/com/example/muaring/domain/music/dto/MusicHistoryDTO.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class MusicHistoryDTO {
 
+    private Long postId;
     private Long musicId;
     private String title;
     private String artist;

--- a/src/main/java/com/example/muaring/domain/social/controller/PostController.java
+++ b/src/main/java/com/example/muaring/domain/social/controller/PostController.java
@@ -2,14 +2,13 @@ package com.example.muaring.domain.social.controller;
 
 import com.example.muaring.common.response.ApiResponse;
 import com.example.muaring.domain.music.dto.MusicHistoryDTO;
-import com.example.muaring.domain.social.dto.post.MusicPostDTO;
-import com.example.muaring.domain.social.dto.post.MusicPostListResponseDTO;
-import com.example.muaring.domain.social.dto.post.MusicPostRequestDTO;
-import com.example.muaring.domain.social.dto.post.TodayPostResponseDTO;
+import com.example.muaring.domain.social.dto.post.*;
 import com.example.muaring.domain.social.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,10 +43,18 @@ public class PostController {
                 .body(ApiResponse.ok(history, "회원의 음악 히스토리 조회가 완료되었습니다."));
     }
 
+    // [GET] /post/followee/today
+    // 팔로우한 사용자 + 내 게시물 조회
     @GetMapping("/followee/today")
-    public ResponseEntity<ApiResponse<List<MusicPostListResponseDTO>>> getTodayFolloweePosts() {
-        List<MusicPostListResponseDTO> response = postService.getTodayFolloweePosts();
-        return ResponseEntity.ok(ApiResponse.ok(response, "팔로우한 사용자의 게시물을 조회했습니다."));
+    public ResponseEntity<ApiResponse<Page<MusicPostFeedResponseDto>>> getTodayFolloweePosts(
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<MusicPostFeedResponseDto> response =
+                postService.getTodayFolloweePosts(pageable);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(response, "팔로우한 사용자의 오늘 게시물을 조회했습니다.")
+        );
     }
 
     @GetMapping("/today")

--- a/src/main/java/com/example/muaring/domain/social/controller/PostController.java
+++ b/src/main/java/com/example/muaring/domain/social/controller/PostController.java
@@ -35,7 +35,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<Page<MusicHistoryDTO>>> getMusicHistoryByMember(
         @RequestParam(required = false) Integer year,
         @RequestParam(required = false) Integer month,
-        @PageableDefault(page = 0, size = 10) Pageable pageable
+        @PageableDefault(page = 0, size = 20) Pageable pageable
     ) {
             Page<MusicHistoryDTO> history = postService.getMusicHistoryByMember(year, month, pageable);
             return ResponseEntity

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -29,6 +29,13 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
             Pageable pageable
     );
 
+    // 그룹 히스토리용: 한 달 동안의 그룹 포스트 전체 (삭제되지 않은 것만), 시간순
+    List<MusicPost> findByGroup_IdAndIsDeletedFalseAndCreatedAtBetweenOrderByCreatedAtAsc(
+            Long groupId,
+            LocalDateTime start,
+            LocalDateTime end
+    );
+
 //    @Query(value = """
 //        SELECT *
 //        FROM music_post mp

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -29,6 +29,20 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
             Pageable pageable
     );
 
+//    @Query(value = """
+//        SELECT *
+//        FROM music_post mp
+//        WHERE mp.member_id IN (
+//            SELECT f.followee_id
+//            FROM follow f
+//            WHERE f.follower_id = :memberId
+//        )
+//        AND mp.created_at >= CURRENT_DATE
+//        AND mp.created_at < CURRENT_DATE + INTERVAL '1 day'
+//        ORDER BY mp.created_at DESC
+//        """, nativeQuery = true)
+//    List<MusicPost> findTodayPostsByFollowees(@Param("memberId") Long memberId);
+
     @Query(value = """
         SELECT *
         FROM music_post mp
@@ -40,9 +54,23 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
         AND mp.created_at >= CURRENT_DATE
         AND mp.created_at < CURRENT_DATE + INTERVAL '1 day'
         ORDER BY mp.created_at DESC
-        """, nativeQuery = true)
-
-    List<MusicPost> findTodayPostsByFollowees(@Param("memberId") Long memberId);
+        """,
+            countQuery = """
+        SELECT COUNT(*)
+        FROM music_post mp
+        WHERE mp.member_id IN (
+            SELECT f.followee_id
+            FROM follow f
+            WHERE f.follower_id = :memberId
+        )
+        AND mp.created_at >= CURRENT_DATE
+        AND mp.created_at < CURRENT_DATE + INTERVAL '1 day'
+        """,
+            nativeQuery = true)
+    Page<MusicPost> findTodayPostsByFollowees(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 
     @Query(value = "SELECT * FROM music_post " +
             "WHERE member_id = :memberId " +

--- a/src/main/java/com/example/muaring/domain/social/service/PostService.java
+++ b/src/main/java/com/example/muaring/domain/social/service/PostService.java
@@ -115,6 +115,7 @@ public class PostService {
         Page<MusicPost> posts = musicPostRepository.findByMemberAndYearMonth(memberId, year, month, pageable);
 
         return posts.map(post -> MusicHistoryDTO.builder()
+                .postId(post.getId())
                 .musicId(post.getMusic().getId())
                 .title(post.getMusic().getName())
                 .artist(post.getMusic().getArtistName())

--- a/src/main/java/com/example/muaring/domain/social/service/PostService.java
+++ b/src/main/java/com/example/muaring/domain/social/service/PostService.java
@@ -12,13 +12,11 @@ import com.example.muaring.domain.music.entity.Music;
 import com.example.muaring.domain.music.exception.MusicErrorCode;
 import com.example.muaring.domain.music.exception.MusicException;
 import com.example.muaring.domain.music.service.MusicService;
-import com.example.muaring.domain.social.dto.post.MusicPostDTO;
-import com.example.muaring.domain.social.dto.post.MusicPostListResponseDTO;
-import com.example.muaring.domain.social.dto.post.MusicPostRequestDTO;
-import com.example.muaring.domain.social.dto.post.TodayPostResponseDTO;
+import com.example.muaring.domain.social.dto.post.*;
 import com.example.muaring.domain.social.exception.post.PostErrorCode;
 import com.example.muaring.domain.social.repository.MusicPostRepository;
 import com.example.muaring.domain.social.entity.MusicPost;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -126,31 +124,17 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<MusicPostListResponseDTO> getTodayFolloweePosts() {
+    public Page<MusicPostFeedResponseDto> getTodayFolloweePosts(Pageable pageable) {
 
         Long memberId = SecurityUtil.getMemberId();
 
-        if (!memberRepository.existsById(memberId)) {
-            throw new MusicException(MusicErrorCode.MEMBER_NOT_FOUND);
-        }
-
-        List<MusicPost> posts = musicPostRepository.findTodayPostsByFollowees(memberId);
-
-        return posts.stream()
-                .map(post -> MusicPostListResponseDTO.builder()
-                        .postId(post.getId())
-                        .memberId(post.getMember().getId())
-                        .memberName(post.getMember().getNickname())
-                        .profileImage(post.getMember().getProfileImage())
-                        .content(post.getContent())
-                        .albumImgUrl(post.getMusic().getAlbumImgUrl())
-                        .musicName(post.getMusic().getName())
-                        .artistName(post.getMusic().getArtistName())
-                        .previewUrl(post.getMusic().getPreviewUrl())
-                        .likeCount(post.getLikeCount().longValue())
-                        .commentCount(post.getCommentCount().longValue())
-                        .build())
-                .toList();
+        // Pagination + sort 된 채로 바로 가져오기
+        Pageable pageableNoSort = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize()
+        );
+        Page<MusicPost> posts = musicPostRepository.findTodayPostsByFollowees(memberId, pageableNoSort);
+        return posts.map(MusicPostFeedResponseDto::from);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 관련 이슈
#9 

## ✨ 작업 내용
- 팔로워 피드 반환 부분 dto를 그룹과 맞췄습니다.
- 그룹 히스토리 조회 기능을 추가했습니다. 연도와 월을 동적으로 필터링하여 조회할 수 있고, null 값으로 둔다면 모두 조회합니다.
- 그룹 프로필 조회 반환 dto를 수정했습니다.
- 게시물 상세 조회 엔드포인트를 변경했습니다.

## 📸 스크린샷(선택)
X

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
X