### PR TITLE
[REFACTOR] 홈 화면 post, 멤버 프로필 관련 리팩토링

### DIFF
--- a/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/example/muaring/domain/group/repository/GroupMemberRepository.java
@@ -62,4 +62,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             Long memberId,
             String name
     );
+
+    // 그룹 멤버인지 여부 반환
+    boolean existsByGroup_IdAndMember_Id(Long groupId, Long memberId);
 }

--- a/src/main/java/com/example/muaring/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/muaring/domain/group/service/GroupService.java
@@ -9,10 +9,12 @@ import com.example.muaring.domain.group.level.GroupLevelService;
 import com.example.muaring.domain.group.repository.*;
 import com.example.muaring.domain.group.repository.projection.GroupIdCategoryNameProjection;
 import com.example.muaring.domain.group.response.GroupException;
+import com.example.muaring.domain.library.repository.LibraryRepository;
 import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.member.exception.MemberException;
 import com.example.muaring.domain.member.repository.MemberRepository;
 import com.example.muaring.domain.member.response.MemberErrorCode;
+import com.example.muaring.domain.member.service.MemberService;
 import com.example.muaring.domain.music.dto.MusicHistoryDTO;
 import com.example.muaring.domain.social.dto.post.MusicPostFeedResponseDto;
 import com.example.muaring.domain.social.entity.MusicPost;
@@ -47,6 +49,8 @@ public class GroupService {
     private final LikeRepository likeRepository;
     private final GroupPlaylistRepository groupPlaylistRepository;
     private final GroupLevelService groupLevelService;
+    private final LibraryRepository libraryRepository;
+    private final MemberService memberService;
 
     // 🍀 그룹 생성
     @Transactional
@@ -103,7 +107,7 @@ public class GroupService {
 
 
     // 🍀 각 조건에 따라 그룹을 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public GroupListResponseDto getGroups(
             String name,            // 검색어
             Boolean isPublic,       // 공개 여부
@@ -225,7 +229,7 @@ public class GroupService {
 
 
     // 🍀 그룹 상세 조회 메서드
-    @Transactional
+    @Transactional(readOnly = true)
     public GroupProfileResponseDto getGroupProfile(Long groupId) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
@@ -257,13 +261,20 @@ public class GroupService {
 
 
     // 🍀 그룹 내 피드 조회 메서드
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<MusicPostFeedResponseDto> getGroupFeed(
             Long groupId,
             Integer year,
             Integer month,
             Pageable pageable
     ) {
+
+        Long viewerId = SecurityUtil.getMemberId();
+
+        // 그룹 멤버 권한 확인
+        if (viewerId == null || !groupMemberRepository.existsByGroup_IdAndMember_Id(groupId, viewerId)) {
+            throw new GroupException(GroupErrorCode.NOT_GROUP_MEMBER);
+        }
 
         Page<MusicPost> posts;
 
@@ -286,17 +297,23 @@ public class GroupService {
             posts = musicPostRepository.findByGroup_Id(groupId, pageable);
         }
 
-        // DTO 변환
-        return posts.map(MusicPostFeedResponseDto::from);
+        return mapToFeedDtosWithLibraryFlag(posts, viewerId);
     }
 
 
     // 🍀 그룹 내 오늘의 피드 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<MusicPostFeedResponseDto> getTodayGroupFeed(
             Long groupId,
             Pageable pageable
     ) {
+        Long viewerId = SecurityUtil.getMemberId();
+
+        // 그룹 멤버 권한 확인
+        if (viewerId == null || !groupMemberRepository.existsByGroup_IdAndMember_Id(groupId, viewerId)) {
+            throw new GroupException(GroupErrorCode.NOT_GROUP_MEMBER);
+        }
+
         LocalDate today = LocalDate.now();
 
         LocalDateTime start = today.atStartOfDay();
@@ -305,7 +322,56 @@ public class GroupService {
         Page<MusicPost> posts = musicPostRepository
                 .findByGroup_IdAndCreatedAtBetween(groupId, start, end, pageable);
 
-        return posts.map(MusicPostFeedResponseDto::from);
+        return mapToFeedDtosWithLibraryFlag(posts, viewerId);
+    }
+
+
+    // 피드에 보관함 여부 + 좋아요 눌렀는지 여부 추가
+    private Page<MusicPostFeedResponseDto> mapToFeedDtosWithLibraryFlag(
+            Page<MusicPost> posts,
+            Long viewerId
+    ) {
+
+        List<MusicPost> content = posts.getContent();
+        if (content.isEmpty()) {
+            return posts.map(post -> MusicPostFeedResponseDto.from(post, false, false));
+        }
+
+        // postIds, musicIds 추출
+        List<Long> postIds = content.stream()
+                .map(MusicPost::getId)
+                .toList();
+
+        List<Long> musicIds = content.stream()
+                .map(p -> p.getMusic().getId())
+                .toList();
+
+        // 내 보관함에 있는 musicId 목록 조회
+        List<Long> inLibraryIds = libraryRepository.findMusicIdsInLibrary(viewerId, musicIds);
+        Set<Long> inLibrarySet = new HashSet<>(inLibraryIds);
+
+        // 내가 좋아요 누른 postId 목록 조회
+        List<Long> likedPostIds = likeRepository.findLikedPostIds(viewerId, postIds);
+        Set<Long> likedSet = new HashSet<>(likedPostIds);
+
+        // 같은 멤버 여러 번 나올 수 있으니까 캐시
+        Map<Long, String> profileUrlCache = new HashMap<>();
+
+        return posts.map(post -> {
+            boolean inLibrary = inLibrarySet.contains(post.getMusic().getId());
+            boolean liked = likedSet.contains(post.getId());
+
+            Member member = post.getMember();
+            Long memberId = member.getId();
+
+            // presigned URL 캐싱해서 member당 한 번만 생성
+            String profileImageUrl = profileUrlCache.computeIfAbsent(
+                    memberId,
+                    id -> memberService.resolveProfileImageUrl(member)
+            );
+
+            return MusicPostFeedResponseDto.from(post, inLibrary, liked, profileImageUrl);
+        });
     }
 
 

--- a/src/main/java/com/example/muaring/domain/library/repository/LibraryRepository.java
+++ b/src/main/java/com/example/muaring/domain/library/repository/LibraryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -23,5 +24,13 @@ public interface LibraryRepository extends JpaRepository<Library, Long> {
     @Modifying
     @Query("DELETE FROM Library l WHERE l.id IN :ids AND l.member = :member")
     void deleteByIdsAndMember(@Param("ids") List<Long> libraryIds, @Param("member") Member member);
+
+    // 현재 로그인한 멤버의 보관함 중, 해당 musicId 리스트에 포함되는 곡들의 musicId 들만 가져오기
+    @Query("select l.music.id from Library l " +
+            "where l.member.id = :memberId and l.music.id in :musicIds")
+    List<Long> findMusicIdsInLibrary(
+            @Param("memberId") Long memberId,
+            @Param("musicIds") Collection<Long> musicIds
+    );
 
 }

--- a/src/main/java/com/example/muaring/domain/library/service/LibraryService.java
+++ b/src/main/java/com/example/muaring/domain/library/service/LibraryService.java
@@ -81,7 +81,7 @@ public class LibraryService {
         Library savedLibrary = libraryRepository.save(library);
 
         return LibraryMusicDTO.builder()
-                .libraryId(library.getId())
+                .libraryId(savedLibrary.getId())
                 .musicId(savedLibrary.getMusic().getId())
                 .title(savedLibrary.getMusic().getName())
                 .artist(savedLibrary.getMusic().getArtistName())

--- a/src/main/java/com/example/muaring/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/muaring/domain/member/service/MemberService.java
@@ -154,7 +154,7 @@ public class MemberService {
         boolean isPublic = member.getIsPublic();  // 비공개 계정 여부
         boolean isFollowing = followRepository.existsByFollowerIdAndFolloweeId(loginMemberId, targetId);  // 팔로우 여부
 
-        long sharedMusicCount = musicPostRepository.countByMemberIdAndIsDeletedIsFalse(targetId);
+        long sharedMusicCount = musicPostRepository.countByMemberIdAndGroupIsNullAndIsDeletedFalse(targetId);
         long followerCount = followRepository.countByFolloweeId(targetId); // targetId 회원을 팔로우하는 사람 수
         long followeeCount = followRepository.countByFollowerId(targetId);  // targetId 회원이 팔로우하는 사람 수
         long joinedGroupCount = groupMemberRepository.countByMemberId(targetId);

--- a/src/main/java/com/example/muaring/domain/music/entity/Music.java
+++ b/src/main/java/com/example/muaring/domain/music/entity/Music.java
@@ -23,13 +23,13 @@ public class Music {
     @Column(name = "spotify_id", length = 50, nullable = false, unique = true)
     private String spotifyId;
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 100, nullable = false)
     private String name;
 
     @Column(name = "artist_id", length = 50, nullable = false)
     private String artistId;
 
-    @Column(name = "artist_name", length = 30, nullable = false)
+    @Column(name = "artist_name", length = 100, nullable = false)
     private String artistName;
 
     @Column(name = "album_name", length = 255, nullable = false)

--- a/src/main/java/com/example/muaring/domain/social/dto/post/MusicPostFeedResponseDto.java
+++ b/src/main/java/com/example/muaring/domain/social/dto/post/MusicPostFeedResponseDto.java
@@ -36,10 +36,15 @@ public class MusicPostFeedResponseDto {
     private boolean isProfile;
     private String content;
     private Integer likeCount;
+    private boolean isLiked;          // 내가 좋아요 눌렀는지
     private Integer commentCount;
+    private boolean isInLibrary;    // 내 보관함에 있는지 여부
     private LocalDateTime createdAt;
 
-    public static MusicPostFeedResponseDto from(MusicPost post) {
+    // 기존 from() : 프로필 URL을 엔티티에서 직접 가져오는 버전
+    public static MusicPostFeedResponseDto from(MusicPost post,
+                                                boolean isInLibrary,
+                                                boolean isLiked) {
         Member member = post.getMember();
         Music music = post.getMusic();
 
@@ -77,8 +82,51 @@ public class MusicPostFeedResponseDto {
                 .isProfile(post.isProfile())
                 .content(post.getContent())
                 .likeCount(post.getLikeCount())
+                .isLiked(isLiked)               // 내가 좋아요 눌렀는지 여부
                 .commentCount(post.getCommentCount())
+                .isInLibrary(isInLibrary)   // 내 보관함에 있는지 여부
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
 
+    // 새로 추가된 from(): 외부에서 profileImageUrl을 강제로 넣어주는 버전
+    public static MusicPostFeedResponseDto from(
+            MusicPost post,
+            boolean isInLibrary,
+            boolean isLiked,
+            String memberProfileImageUrl
+    ) {
+        Member member = post.getMember();
+        Music music = post.getMusic();
+
+        Long groupId = post.getGroup() != null ? post.getGroup().getId() : null;
+
+        return MusicPostFeedResponseDto.builder()
+                .postId(post.getId())
+                .groupId(groupId)
+
+                // 작성자
+                .memberId(member.getId())
+                .memberNickname(member.getNickname())
+                .memberProfileImageUrl(memberProfileImageUrl)
+
+                // 음악
+                .musicId(music.getId())
+                .spotifyId(music.getSpotifyId())
+                .musicName(music.getName())
+                .artistId(music.getArtistId())
+                .artistName(music.getArtistName())
+                .albumName(music.getAlbumName())
+                .albumImgUrl(music.getAlbumImgUrl())
+                .durationMs(music.getDurationMs())
+
+                // 포스트 정보
+                .isProfile(post.isProfile())
+                .content(post.getContent())
+                .likeCount(post.getLikeCount())
+                .isLiked(isLiked)
+                .commentCount(post.getCommentCount())
+                .isInLibrary(isInLibrary)
                 .createdAt(post.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/example/muaring/domain/social/exception/post/PostErrorCode.java
+++ b/src/main/java/com/example/muaring/domain/social/exception/post/PostErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PostErrorCode implements ErrorCode {
 
+    // 403
+    UNAUTHROIZED(6003, HttpStatus.UNAUTHORIZED, "권한이 존재하지 않습니다."),
+
     // 404
     POST_NOT_FOUND(6001, HttpStatus.NOT_FOUND, "게시물이 존재하지 않습니다."),
 

--- a/src/main/java/com/example/muaring/domain/social/repository/LikeRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/LikeRepository.java
@@ -2,8 +2,11 @@ package com.example.muaring.domain.social.repository;
 
 import com.example.muaring.domain.social.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +17,10 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     // 특정 게시물에 특정 회원이 좋아요를 눌렀는지 확인
     boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    // 좋아요 누른 게시물 목록
+    @Query("select l.post.id from Like l where l.member.id = :memberId and l.post.id in :postIds")
+    List<Long> findLikedPostIds(@Param("memberId") Long memberId,
+                                @Param("postIds") List<Long> postIds);
+
 }

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -120,11 +120,16 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
     );
 
 
-    @Query(value = "SELECT * FROM music_post " +
-            "WHERE member_id = :memberId " +
-            "AND created_at >= CURRENT_DATE " +
-            "AND created_at < CURRENT_DATE + INTERVAL '1 day'",
-            nativeQuery = true)
+    @Query(value = """
+        SELECT *
+        FROM music_post
+        WHERE member_id = :memberId
+          AND group_id IS NULL
+          AND created_at >= CURRENT_DATE
+          AND created_at < CURRENT_DATE + INTERVAL '1 day'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """, nativeQuery = true)
     Optional<MusicPost> findTodayPostByMember(@Param("memberId") Long memberId);
 
 

--- a/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
+++ b/src/main/java/com/example/muaring/domain/social/repository/MusicPostRepository.java
@@ -15,14 +15,14 @@ import java.util.Optional;
 public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
 
     @Query("""
-    SELECT mp
-    FROM MusicPost mp
-    WHERE mp.member.id = :memberId
-      AND YEAR(mp.createdAt) = :year
-      AND MONTH(mp.createdAt) = :month
-    ORDER BY mp.createdAt DESC
+        SELECT mp
+        FROM MusicPost mp
+        WHERE mp.member.id = :memberId
+          AND mp.group IS NULL
+          AND YEAR(mp.createdAt) = :year
+          AND MONTH(mp.createdAt) = :month
+        ORDER BY mp.createdAt ASC
     """)
-
     Page<MusicPost> findByMemberAndYearMonth(
             @Param("memberId") Long memberId,
             @Param("year") Integer year,
@@ -133,7 +133,7 @@ public interface MusicPostRepository extends JpaRepository<MusicPost, Long> {
     Optional<MusicPost> findTodayPostByMember(@Param("memberId") Long memberId);
 
 
-    long countByMemberIdAndIsDeletedIsFalse( Long memberId);
+    long countByMemberIdAndGroupIsNullAndIsDeletedFalse(Long memberId);
 
     @Query("select count(mp) from MusicPost mp where mp.group.id = :groupId and mp.isDeleted = false")
     int countActiveByGroupId(@Param("groupId") Long groupId);

--- a/src/main/java/com/example/muaring/domain/social/service/PostService.java
+++ b/src/main/java/com/example/muaring/domain/social/service/PostService.java
@@ -7,8 +7,10 @@ import com.example.muaring.domain.group.level.GroupActivityType;
 import com.example.muaring.domain.group.level.GroupLevelService;
 import com.example.muaring.domain.group.repository.GroupPlaylistRepository;
 import com.example.muaring.domain.group.repository.GroupRepository;
+import com.example.muaring.domain.library.repository.LibraryRepository;
 import com.example.muaring.domain.member.entity.Member;
 import com.example.muaring.domain.member.repository.MemberRepository;
+import com.example.muaring.domain.member.service.MemberService;
 import com.example.muaring.domain.music.dto.MusicHistoryDTO;
 import com.example.muaring.domain.music.entity.Music;
 import com.example.muaring.domain.music.exception.MusicErrorCode;
@@ -16,6 +18,8 @@ import com.example.muaring.domain.music.exception.MusicException;
 import com.example.muaring.domain.music.service.MusicService;
 import com.example.muaring.domain.social.dto.post.*;
 import com.example.muaring.domain.social.exception.post.PostErrorCode;
+import com.example.muaring.domain.social.exception.post.PostException;
+import com.example.muaring.domain.social.repository.LikeRepository;
 import com.example.muaring.domain.social.repository.MusicPostRepository;
 import com.example.muaring.domain.social.entity.MusicPost;
 import org.springframework.data.domain.PageRequest;
@@ -27,7 +31,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +43,9 @@ public class PostService {
     private final MusicPostRepository musicPostRepository;
     private final MusicService musicService;
     private final GroupLevelService groupLevelService;
+    private final LibraryRepository libraryRepository;
+    private final LikeRepository likeRepository;
+    private final MemberService memberService;
 
     @Transactional
     public MusicPostDTO createMusicPost(MusicPostRequestDTO request) {
@@ -149,16 +156,69 @@ public class PostService {
     @Transactional(readOnly = true)
     public Page<MusicPostFeedResponseDto> getTodayFolloweePosts(Pageable pageable) {
 
-        Long memberId = SecurityUtil.getMemberId();
+        Long viewerId = SecurityUtil.getMemberId();
+
+        if (viewerId == null) {
+            throw new PostException(PostErrorCode.UNAUTHROIZED);
+        }
 
         // Pagination + sort 된 채로 바로 가져오기
         Pageable pageableNoSort = PageRequest.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize()
         );
-        Page<MusicPost> posts = musicPostRepository.findTodayPostsByFollowees(memberId, pageableNoSort);
-        return posts.map(MusicPostFeedResponseDto::from);
+        Page<MusicPost> posts = musicPostRepository.findTodayPostsByFollowees(viewerId, pageableNoSort);
+        return mapToFeedDtosWithLibraryFlag(posts, viewerId);
     }
+
+    // 피드에 보관함 여부 + 좋아요 눌렀는지 여부 추가
+    private Page<MusicPostFeedResponseDto> mapToFeedDtosWithLibraryFlag(
+            Page<MusicPost> posts,
+            Long viewerId
+    ) {
+
+        List<MusicPost> content = posts.getContent();
+        if (content.isEmpty()) {
+            return posts.map(post -> MusicPostFeedResponseDto.from(post, false, false));
+        }
+
+        // postIds, musicIds 추출
+        List<Long> postIds = content.stream()
+                .map(MusicPost::getId)
+                .toList();
+
+        List<Long> musicIds = content.stream()
+                .map(p -> p.getMusic().getId())
+                .toList();
+
+        // 내 보관함에 있는 musicId 목록 조회
+        List<Long> inLibraryIds = libraryRepository.findMusicIdsInLibrary(viewerId, musicIds);
+        Set<Long> inLibrarySet = new HashSet<>(inLibraryIds);
+
+        // 내가 좋아요 누른 postId 목록 조회
+        List<Long> likedPostIds = likeRepository.findLikedPostIds(viewerId, postIds);
+        Set<Long> likedSet = new HashSet<>(likedPostIds);
+
+        // 같은 멤버가 여러 게시글을 쓸 수 있으니까 presigned URL 캐싱
+        Map<Long, String> profileUrlCache = new HashMap<>();
+
+        return posts.map(post -> {
+            boolean inLibrary = inLibrarySet.contains(post.getMusic().getId());
+            boolean liked = likedSet.contains(post.getId());
+
+            Member member = post.getMember();
+            Long memberId = member.getId();
+
+            // presigned URL 캐싱해서 member당 한 번만 생성
+            String profileImageUrl = profileUrlCache.computeIfAbsent(
+                    memberId,
+                    id -> memberService.resolveProfileImageUrl(member)
+            );
+
+            return MusicPostFeedResponseDto.from(post, inLibrary, liked, profileImageUrl);
+        });
+    }
+
 
     @Transactional(readOnly = true)
     public TodayPostResponseDTO getTodayPostByMember() {


### PR DESCRIPTION
## 📌 관련 이슈
#93

## ✨ 작업 내용
- 홈 화면 post 조회 시 좋아요+보관함 여부를 같이 내리도록 했습니다.
- 히스토리 조회 시 mp.group IS NULL 인 것만 조회하도록 수정했습니다.
- 히스토리 조회 시 DESC -> ASC 조회하도록 수정했습니다.
- 공유한 음악 개수 조회 시 프로필에 올라가는 게시물 개수로 카운트하도록 했습니다.

## 📸 스크린샷(선택)
X

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
X