### PR TITLE
chore: 사용자의 오늘 공유한 음악 조회 api를 멤버 아이디를 파라미터로 받게 수정

### DIFF
--- a/src/main/java/com/example/muaring/domain/social/controller/PostController.java
+++ b/src/main/java/com/example/muaring/domain/social/controller/PostController.java
@@ -41,9 +41,13 @@ public class PostController {
         );
     }
 
-    @GetMapping("/today")
-    public ResponseEntity<ApiResponse<TodayPostResponseDTO>> getTodayPost() {
-        TodayPostResponseDTO response = postService.getTodayPostByMember();
-        return ResponseEntity.ok(ApiResponse.ok(response, "오늘의 게시물 조회 완료"));
+    // [GET] /post/{memberId}/today
+    // 사용자의 오늘 공유한 음악 조회
+    @GetMapping("/{memberId}/today")
+    public ResponseEntity<ApiResponse<TodayPostResponseDTO>> getTodayPostByMemberId(
+            @PathVariable Long memberId
+    ) {
+        TodayPostResponseDTO response = postService.getTodayPostByMember(memberId);
+        return ResponseEntity.ok(ApiResponse.ok(response, "멤버의 오늘의 게시물 조회 완료"));
     }
 }

--- a/src/main/java/com/example/muaring/domain/social/service/PostService.java
+++ b/src/main/java/com/example/muaring/domain/social/service/PostService.java
@@ -199,19 +199,20 @@ public class PostService {
 
 
     @Transactional(readOnly = true)
-    public TodayPostResponseDTO getTodayPostByMember() {
+    public TodayPostResponseDTO getTodayPostByMember(Long memberId) {
 
-        Long memberId = SecurityUtil.getMemberId();
-
+        // 멤버 존재 여부 확인
         if (!memberRepository.existsById(memberId)) {
             throw new MusicException(MusicErrorCode.MEMBER_NOT_FOUND);
         }
 
+        // 오늘의 게시물 조회
         MusicPost post = musicPostRepository.findTodayPostByMember(memberId)
                 .orElseThrow(() -> new MusicException(PostErrorCode.POST_NOT_FOUND));
 
         Music music = post.getMusic();
 
+        // DTO 반환
         return TodayPostResponseDTO.builder()
                 .postId(post.getId())
                 .musicId(music.getId())


### PR DESCRIPTION
## 📌 관련 이슈
관련있는 이슈 번호(#000)을 적어주세요.
#19 

## ✨ 작업 내용
- 사용자의 오늘 공유한 음악 조회 api를 멤버 아이디를 파라미터로 받게 수정

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 원래 로그인한 사용자 id 기준으로 오늘 공유한 음악을 조회했는데 생각해보니까 그러면 다른 사용자의 오늘 공유한 음악은 응답하지 못해서 memberId 기준으로 조회하도록 로직과 api url을 수정했습니다.